### PR TITLE
fix #30: add Dummy.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ limitations under the License.
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
-            <skipIfEmpty>true</skipIfEmpty>
+            <skipIfEmpty>false</skipIfEmpty>
             <archive>
               <index>true</index>
               <manifest>

--- a/src/main/java/org/mal-lang/corelang/Dummy.java
+++ b/src/main/java/org/mal-lang/corelang/Dummy.java
@@ -1,2 +1,0 @@
-package org.mal_lang.corelang;
-class Dummy{}

--- a/src/main/java/org/mal-lang/corelang/Dummy.java
+++ b/src/main/java/org/mal-lang/corelang/Dummy.java
@@ -1,0 +1,2 @@
+package org.mal_lang.corelang;
+class Dummy{}


### PR DESCRIPTION
This is a workaround for #30. By adding a java-file we force `coreLang-0.1.0.jar` to be generated.

The MAL reference compiler uses (only?) `*.mal`-files as input. This means that any project that uses coreLang along with the reference compiler actually uses `coreLang-0.1.0-source.jar`, not `coreLang-0.1.0.jar`. The problem is that maven expects to find a `coreLang-0.1.0.jar` when downloading coreLang in order to work properly.

Another workaround could perhaps be to copy the `*.mal`-files into `coreLang-0.1.0.jar` as part of the buildprocess, but the above solves the problem for now.

You can't build e.g. icsLang with the reference compiler unless you already have `coreLang-0.1.0.jar` installed. Steps to reproduce:
1. `export JAVA_HOME=/usr/lib/jvm/java-11-openjdk   # setup on archlinux. other OS do this differently.`
1. `rm -rf ~/.m2/repository/org/mal-lang/corelang/0.1.0`
1. `cd coreLang`
1. `mvn install # only installs coreLang-0.1.0-source.jar not coreLang-0.1.0.jar`
1. `cd icsLang`
1. `mvn test   # fails`
1. `cp ~/.m2/repository/org/mal-lang/corelang/0.1.0/corelang-0.1.0{-source,}.jar`
1. `mvn test   # succeeds`

