### PR TITLE
Transit Data Access Fix

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -746,11 +746,7 @@ category Networking {
             clientApplications.networkRespondConnect,
             accessNetworkData,
             networkForwarding,
-            denialOfService,
-            eavesdrop,
-            bypassEavesdropProtection,
-            manInTheMiddle,
-            bypassMitMProtection
+            denialOfService
 
       | networkForwarding
         developer info: "By using the allowed connections (connection rules), forwarding from one network to another network or applications can happen. Additionally, client-side attacks (like attemptTransmitResponse) can also be initiated from here."
@@ -765,9 +761,10 @@ category Networking {
 
       | accessNetworkData
         user info: "Access also the data that are network-wide available."
-        ->  transitData.attemptAccess,
-            transitData.attemptEavesdrop,
-            transitData.attemptManInTheMiddle
+        ->  eavesdrop,
+            bypassEavesdropProtection,
+            manInTheMiddle,
+            bypassMitMProtection
 
       # eavesdropDefense
         user info: "This defense protects from eavesdrop attacks. If this defense is disabled, then it is equivalent to the network being considered a broadcast network."
@@ -782,7 +779,8 @@ category Networking {
       & eavesdrop {C}
         user info: "An attacker that performs an eavesdrop attack on a network tries to access all the transfered data over that network."
         ->  allowedApplicationConnections().attemptEavesdropOnDataInTransit,
-            allNetApplications().transitData.attemptEavesdrop
+            allNetApplications().transitData.attemptEavesdrop,
+            transitData.attemptEavesdrop
 
       | bypassEavesdropProtection [HardAndUncertain]
         user info: "The eavesdrop protection can be bypassesed."
@@ -792,7 +790,8 @@ category Networking {
       & manInTheMiddle {C, I}
         user info: "An attacker that performs a MitM attack on a network tries to modifiy all the transfered data over that network."
         ->  allowedApplicationConnections().attemptManInTheMiddleOnDataInTransit,
-            allNetApplications().transitData.attemptManInTheMiddle
+            allNetApplications().transitData.attemptManInTheMiddle,
+            transitData.attemptManInTheMiddle
 
       | bypassMitMProtection [HardAndUncertain]
         user info: "The MitM protection can be bypassesed."
@@ -806,9 +805,9 @@ category Networking {
             transitData.attemptEavesdrop
     }
 
-    asset RoutingFirewall extends Application 
+    asset RoutingFirewall extends Application
       user info: "A routing firewall specifies a router with firewall capabilities that connects many networks."
-    { 
+    {
       | denialOfService {A}
        user info: "A DoS attack should cascade on the connected networks and associated connections"
         ->  connectionRules.attemptDenialOfService

--- a/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
@@ -233,9 +233,8 @@ public class DataPrivilegesTest extends CoreLangTest {
         model.outerData.write.assertUncompromised();
         model.innerData.write.assertUncompromised();
 
-        // mitm implies delete-privileges
-        model.outerData.delete.assertCompromisedInstantaneously();
-        model.innerData.delete.assertCompromisedInstantaneously();
+        model.outerData.delete.assertUncompromised();
+        model.innerData.delete.assertUncompromised();
     }
 
     private static class DataToDataModel {


### PR DESCRIPTION
This commit makes it so that the read, write, and delete attack steps only trigger via eavesdrop(only read) or man in the middle(all three) attack steps.

In addition to the changes discussed with @skatsikeas this commit also removes access via accessNetworkData. I *believe* that is the intention, but I may be incorrect. @skatsikeas can you confirm that we only expect to expose data transiting over the network via eavesdrop and man in the middle?