### PR TITLE
Rework data in transit

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -232,7 +232,10 @@ category ComputeResources {
             attemptLocalConnectVulnOnHost,
             attemptUseVulnerability,   // Connection to all possible vulnerabilities that might be connected to the Application
             containedData.attemptAccessFromIdentity, // This also enables the use of compromised identites but only after specificAccess is reached
-            transitData.attemptAccessFromIdentity,
+            transitData.identityAttemptRead, // Any data in transit can be read whether this Application is the sender or the recipient
+            transitData.attemptIdentityWriteDataInTransitFromApplication,
+            clientApplicationConnections().attemptWriteDataInTransit, // Only data in transit that initiate from this Application can be written
+            clientApplicationConnections().attemptDenyDataInTransit,  // or denied
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections  // and access the network(s) and connections on/to which the app is connected
 
@@ -272,7 +275,10 @@ category ComputeResources {
             executionPrivIds.assume,  // Assume also the execution privilege identities of this application
             executionPrivGroups.compromiseGroup,
             containedData.attemptAccess,  // and access on all the contained data
-            transitData.attemptAccess,
+            transitData.attemptRead, // Any data in transit can be read whether this Application is the sender or the recipient
+            transitData.attemptWriteDataInTransitFromApplication,
+            clientApplicationConnections().attemptWriteDataInTransit, // Only data in transit that initiate from this Application can be written
+            clientApplicationConnections().attemptDenyDataInTransit,  // or denied
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
@@ -418,7 +424,7 @@ category ComputeResources {
       | deny {A}
         user info: "The attacker can deny some or all functionality and data pertaining to this application/service as well as executed applications."
         ->  containedData.attemptDeny,
-            transitData.attemptDeny,
+            transitData.attemptDenyDataInTransitFromApplication,
             appExecutedApps.deny
 
       & denyFromConnectionRule @hidden
@@ -587,6 +593,39 @@ category DataResources {
           ->  attemptRead,
               attemptWrite,
               attemptApplicationRespondConnect
+
+        | attemptWriteDataInTransitFromApplication @hidden
+          developer info: "Intermediate attack step to allow data in transit to be written from the Application side."
+          ->  writeDataInTransit
+
+        | attemptIdentityWriteDataInTransitFromApplication @hidden
+          developer info: "Intermediate attack step to allow data in transit to be written if the Identity associated is also compromised from the Application side."
+          ->  identityWriteDataInTransit
+
+        | attemptWriteDataInTransitFromConnectionRule @hidden
+          developer info: "Intermediate attack step to allow data in transit to be written from the ConnectionRule side."
+          ->  writeDataInTransit,
+              identityWriteDataInTransit
+
+        & identityWriteDataInTransit @hidden {C, I}
+          developer info: "For Data in transit to be witten via an Application they have to be reachable from an outgoing ConnectionRule as well."
+          ->  identityAttemptWrite
+
+        & writeDataInTransit @hidden {C, I}
+          developer info: "For Data in transit to be witten via an Application they have to be reachable from an outgoing ConnectionRule as well."
+          ->  attemptWrite
+
+        | attemptDenyDataInTransitFromApplication @hidden
+          developer info: "Intermediate attack step to allow data in transit to be denied from the Application side."
+          ->  denyDataInTransit
+
+        | attemptDenyDataInTransitFromConnectionRule @hidden
+          developer info: "Intermediate attack step to allow data in transit to be denied from the ConnectionRule side."
+          ->  denyDataInTransit
+
+        & denyDataInTransit @hidden {C, I}
+          developer info: "For Data in transit to be denied via an Application they have to be reachable from an outgoing ConnectionRule as well."
+          ->  attemptDeny
 
         | compromiseAppOrigin
           user info: "If origin data are modified/written then the software product is also compromised which effectively also compromises the application."
@@ -880,9 +919,7 @@ category Networking {
 
       | successfulEavesdrop @hidden
         developer info: "This is an intermediate attack step to prevent repeating code."
-        ->  allowedApplicationConnections().attemptEavesdropOnDataInTransit,
-            allNetApplications().transitData.attemptEavesdrop,
-            transitData.attemptEavesdrop
+        ->  transitData.attemptEavesdrop
 
       & manInTheMiddle {C, I}
         user info: "An attacker that performs a MitM attack on a network tries to modifiy all the transfered data over that network."
@@ -894,9 +931,7 @@ category Networking {
 
       | successfulManInTheMiddle @hidden
         developer info: "This is an intermediate attack step to prevent repeating code."
-        ->  allowedApplicationConnections().attemptManInTheMiddleOnDataInTransit,
-            allNetApplications().transitData.attemptManInTheMiddle,
-            transitData.attemptManInTheMiddle
+        ->  transitData.attemptManInTheMiddle
 
       & eavesdropAfterPhysicalAccess @hidden {C}
         user info: "If a network is not a switching network and the attacker has physical access on it, eavesdrop can happen."
@@ -932,7 +967,9 @@ category Networking {
             transmitResponse,
             denialOfService,
             eavedropOnDataInTransit,
-            mainInTheMiddleOnDataInTransit
+            mainInTheMiddleOnDataInTransit,
+            writeDataInTransit,
+            denyDataInTransit
 
       # filtered [Disabled]
         user info: "If enabled, then the traffic is considered to be filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication (i.e. network-level vulnerabilities cannot be exploited)."
@@ -995,7 +1032,24 @@ category Networking {
 
       & mainInTheMiddleOnDataInTransit @hidden
         user info: "Via a ConnectionRule a MitM attack can be done on the transitData of the associated Applications. This attack will be launched from the Network asset."
-        ->  allApplications().transitData.attemptManInTheMiddle
+        ->  clientApplications().transitData.attemptManInTheMiddle
+
+      | attemptWriteDataInTransit @hidden
+        developer info: "Intermediate attack step."
+        ->  writeDataInTransit
+
+      & writeDataInTransit @hidden
+        developer info: "Only trigger write on Data in transit on client connections."
+        ->  (networks  \/ inNetworks  \/ diodeInNetworks).transitData.attemptWriteDataInTransitFromConnectionRule
+
+      | attemptDenyDataInTransit @hidden
+        developer info: "Intermediate attack step."
+        ->  denyDataInTransit
+
+      & denyDataInTransit @hidden
+        developer info: "Only trigger deny on Data in transit on client connections."
+        ->  (networks  \/ inNetworks  \/ diodeInNetworks).transitData.attemptDenyDataInTransitFromConnectionRule
+
     }
 
 }

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -234,8 +234,8 @@ category ComputeResources {
             containedData.attemptAccessFromIdentity, // This also enables the use of compromised identites but only after specificAccess is reached
             transitData.identityAttemptRead, // Any data in transit can be read whether this Application is the sender or the recipient
             transitData.attemptIdentityWriteDataInTransitFromApplication,
-            clientApplicationConnections().attemptWriteDataInTransit, // Only data in transit that initiate from this Application can be written
-            clientApplicationConnections().attemptDenyDataInTransit,  // or denied
+            clientApplicationConnections().attemptAllowWriteDataInTransit, // Only data in transit that initiate from this Application can be written
+            clientApplicationConnections().attemptAllowDenyDataInTransit,  // or denied
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections  // and access the network(s) and connections on/to which the app is connected
 
@@ -277,8 +277,8 @@ category ComputeResources {
             containedData.attemptAccess,  // and access on all the contained data
             transitData.attemptRead, // Any data in transit can be read whether this Application is the sender or the recipient
             transitData.attemptWriteDataInTransitFromApplication,
-            clientApplicationConnections().attemptWriteDataInTransit, // Only data in transit that initiate from this Application can be written
-            clientApplicationConnections().attemptDenyDataInTransit,  // or denied
+            clientApplicationConnections().attemptAllowWriteDataInTransit, // Only data in transit that initiate from this Application can be written
+            clientApplicationConnections().attemptAllowDenyDataInTransit,  // or denied
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
@@ -968,8 +968,8 @@ category Networking {
             denialOfService,
             eavedropOnDataInTransit,
             mainInTheMiddleOnDataInTransit,
-            writeDataInTransit,
-            denyDataInTransit
+            allowWriteDataInTransit,
+            allowDenyDataInTransit
 
       # filtered [Disabled]
         user info: "If enabled, then the traffic is considered to be filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication (i.e. network-level vulnerabilities cannot be exploited)."
@@ -1034,19 +1034,19 @@ category Networking {
         user info: "Via a ConnectionRule a MitM attack can be done on the transitData of the associated Applications. This attack will be launched from the Network asset."
         ->  clientApplications().transitData.attemptManInTheMiddle
 
-      | attemptWriteDataInTransit @hidden
+      | attemptAllowWriteDataInTransit @hidden
         developer info: "Intermediate attack step."
-        ->  writeDataInTransit
+        ->  allowWriteDataInTransit
 
-      & writeDataInTransit @hidden
+      & allowWriteDataInTransit @hidden
         developer info: "Only trigger write on Data in transit on client connections."
         ->  (networks  \/ inNetworks  \/ diodeInNetworks).transitData.attemptWriteDataInTransitFromConnectionRule
 
-      | attemptDenyDataInTransit @hidden
+      | attemptAllowDenyDataInTransit @hidden
         developer info: "Intermediate attack step."
-        ->  denyDataInTransit
+        ->  allowDenyDataInTransit
 
-      & denyDataInTransit @hidden
+      & allowDenyDataInTransit @hidden
         developer info: "Only trigger deny on Data in transit on client connections."
         ->  (networks  \/ inNetworks  \/ diodeInNetworks).transitData.attemptDenyDataInTransitFromConnectionRule
 

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -204,7 +204,7 @@ category ComputeResources {
             clientApplicationConnections().attemptConnectToApplications,
             clientApplicationConnections().attemptTransmit,
             serverApplicationConnections().attemptTransmitResponse, // Since we are on the Application we want to use the serverAppConnection to initiate trasmitResponse.
-            allApplicationConnections().attemptAccessNetworks
+            clientApplicationConnections().attemptAccessNetworks
 
       | networkRequestConnect
         user info: "The attacker has successfully sent a request to the (server) application. This can be used to exploit a vulnerability."

--- a/src/test/java/org/mal_lang/corelang/test/DataInTransitTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataInTransitTest.java
@@ -1,0 +1,99 @@
+package org.mal_lang.corelang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class DataInTransitTest extends CoreLangTest {
+    private static class DataInTransitTestModel {
+        /*
+               --------- DataInTransit -----------> Data Out
+               |                                      |
+               |                                DataInTransit
+               |                                      |
+               v                                      v
+        Application <-In-> ConnectionIn <--> Network A
+               ^  ^
+              Out |------------------------
+               v                         |
+        ConnectionOut              DataInTransit
+               ^                         |
+               |                         |
+               v                         v
+        Network B <-- DataInTransit --> Data In
+
+        Attacker's entry points: Application.FullAccess, NetworkA.access
+        */
+        public final Network netA = new Network("NetworkA");
+        public final Network netB = new Network("NetworkB");
+        public final ConnectionRule connIn = new ConnectionRule("ConnectionIn");
+        public final ConnectionRule connOut = new ConnectionRule("ConnectionOut");
+        public final Application app = new Application("Application");
+        public final Data dataIn = new Data("data_in", false, false);
+        public final Data dataOut = new Data("data_out", false, false);
+
+        public DataInTransitTestModel() {
+            app.addIngoingAppConnections(connIn);
+            app.addOutgoingAppConnections(connOut);
+            app.addTransitData(dataIn);
+            app.addTransitData(dataOut);
+            connIn.addNetworks(netA);
+            connOut.addNetworks(netB);
+            netA.addTransitData(dataIn);
+            netB.addTransitData(dataOut);
+
+        }
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+  }
+
+    @Test
+    public void testDataInTransitApplicationAttackTest() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new DataInTransitTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.app.fullAccess);
+        attacker.attack();
+
+        model.dataIn.read.assertCompromisedInstantaneously();
+        model.dataIn.write.assertUncompromised();
+
+        model.dataOut.read.assertCompromisedInstantaneously();
+        model.dataOut.write.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testDataInTransitNetworkAAttackTest() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new DataInTransitTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.netA.attemptAccess);
+        attacker.attack();
+
+        model.dataIn.read.assertCompromisedInstantaneously();
+        model.dataIn.write.assertCompromisedInstantaneously();
+
+        model.dataOut.read.assertUncompromised();
+        model.dataOut.write.assertUncompromised();
+    }
+
+    @Test
+    public void testDataInTransitNetworkBAttackTest() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new DataInTransitTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.netB.attemptAccess);
+        attacker.attack();
+
+        model.dataIn.read.assertUncompromised();
+        model.dataIn.write.assertUncompromised();
+
+        model.dataOut.read.assertCompromisedInstantaneously();
+        model.dataOut.write.assertCompromisedInstantaneously();
+    }
+
+}


### PR DESCRIPTION
**Data** in transit should only be written from an **Application** if the data are sent via a Network that has a outgoing **ConnectionRule** associated with the **Application**.

**Data** in transit can be read if accessible either the **Network** or any **Applications** through which they transits. If accessed over a **Network** they can be written as well. However, if they accessed through an **Application** they should only be written if they are sent from that **Application**, not received. The current implementation on master created scenarios where access on the **Application** receiving the **Data** were able to trigger a write on them.

In addition to this some attack steps on **Data** in transit were triggered where they should not have been. This led to all **Data** in transit associated with the same **Application** to be compromised if any of the **Network** assets they were connected to were compromised.