### PR TITLE
Update filtered defence on the ConnectionRule to work after the vulnerability redesign

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -205,7 +205,8 @@ category ComputeResources {
 
       # airGapped
         developer info: "An Application that is within an airgapped network cannot initiate any connections outside the local network"
-        ->  networkConnectFromReverseTakeover
+        ->  networkConnectFromReverseTakeover,
+            reverseReach
 
       | networkConnect
         user info: "An attacker can connect to any network exposed application and attempt to authenticate or trigger vulnerabilities."
@@ -213,6 +214,18 @@ category ComputeResources {
             attemptUseVulnerability, // Connection to all possible vulnerabilities that might be connected to the Application
             allVulnerabilities().networkAccessAchieved,
             softwareProductVulnerabilityNetworkAccessAchieved
+
+      | attemptReverseReach @hidden
+        developer info: "Intermediate attack step."
+        ->  reverseReach
+
+      & reverseReach @hidden
+        developer info: "Reverse reach is used to determine whether or not the attacker can be reached by the user."
+        ->  networks.attemptReverseReach,
+            clientAccessNetworks.attemptReverseReach,
+            serverApplicationConnections().attemptReverseReach,
+            appExecutedApps.attemptReverseReach,
+            unsafeUserActivityConnect
 
       | networkConnectWithoutTriggeringVulnerabilities @hidden
         developer info: "This attack step is used if the network connection occurs via a filtered ConnectionRule, in which case the attacker can still authenticate, but they cannot trigger vulnerabilities."
@@ -259,7 +272,8 @@ category ComputeResources {
             clientApplicationConnections().attemptAllowWriteDataInTransit, // Only data in transit that initiate from this Application can be written
             clientApplicationConnections().attemptAllowDenyDataInTransit,  // or denied
             attemptApplicationRespondConnectThroughData,
-            accessNetworkAndConnections  // and access the network(s) and connections on/to which the app is connected
+            accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
+            attemptReverseReach
 
       | attemptLocalConnectVulnOnHost [HardAndUncertain]
         user info: "The attacker is able to break out of an application container/sandbox and try to exploit any vulnerability of the hypervisor/host application"
@@ -305,7 +319,8 @@ category ComputeResources {
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
             managedRoutingFw.fullAccess, // if the routing firewall manager app is compromised the routing firewall should also be compromised
-            specificAccess // And also provide specificAccess, mainly for completeness and more intuitive results
+            specificAccess, // And also provide specificAccess, mainly for completeness and more intuitive results
+            attemptReverseReach
 
       | physicalAccessAchieved @hidden
         developer info: "Intermediate attack step used to propagate physical access throughout application nesting."
@@ -313,10 +328,18 @@ category ComputeResources {
             softwareProductVulnerabilityPhysicalAccessAchieved,
             appExecutedApps.physicalAccessAchieved
 
+      | attemptUnsafeUserActivityConnect @hidden
+        developer info: "Intermediate attack step."
+        ->  unsafeUserActivityConnect
+
+      & unsafeUserActivityConnect @hidden
+        developer info: "This attack step represents the user creating a connection to the attacker through their unsafe actions. It can only occur if the user can reach the attacker via networking assets and/or Applications"
+        ->  localConnect,
+            networkConnect
+
       | attemptUnsafeUserActivityWithLowPrivileges
         developer info: "This attack step represents a user with low privileges on this application engaging in unsafe behaviour that could lead to exposing the application to the attacker."
-        ->  localConnect,
-            networkConnect,
+        ->  attemptUnsafeUserActivityConnect,
             allVulnerabilities().lowPrivilegesAchieved,
             allVulnerabilities().userInteractionAchieved,
             softwareProductVulnerabilityLowPrivilegesAchieved,
@@ -324,8 +347,7 @@ category ComputeResources {
 
       | attemptUnsafeUserActivityWithHighPrivileges
         developer info: "This attack step represents a user with high privileges on this application engaging in unsafe behaviour that could lead to exposing the application to the attacker."
-        ->  localConnect,
-            networkConnect,
+        ->  attemptUnsafeUserActivityConnect,
             allVulnerabilities().highPrivilegesAchieved,
             allVulnerabilities().userInteractionAchieved,
             softwareProductVulnerabilityHighPrivilegesAchieved,
@@ -1005,7 +1027,18 @@ category Networking {
             clientApplications.networkRespondConnect,
             accessNetworkData,
             networkForwarding,
-            denialOfService
+            denialOfService,
+            attemptReverseReach
+
+      | attemptReverseReach @hidden
+        developer info: "Intermediate attack step."
+        ->  reverseReach
+
+      & reverseReach @hidden
+        developer info: "Reverse reach is used to determine whether or not the attacker can be reached by the user."
+        ->  (netConnections \/ ingoingNetConnections \/ diodeIngoingNetConnections).attemptReverseReach,
+            clientApplications.attemptReverseReach,
+            applications.attemptReverseReach
 
       | networkForwarding
         developer info: "By using the allowed connections (connection rules), forwarding from one network to another network or applications can happen. Additionally, client-side attacks (like attemptTransmitResponse) can also be initiated from here."
@@ -1096,13 +1129,24 @@ category Networking {
             eavedropOnDataInTransit,
             manInTheMiddleOnDataInTransit,
             allowWriteDataInTransit,
-            allowDenyDataInTransit
+            allowDenyDataInTransit,
+            reverseReach
 
       # payloadInspection [Disabled]
         user info: "If enabled, then the traffic is considered to be filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication (i.e. network-level vulnerabilities cannot be exploited)."
-        ->  connectToApplications
+        ->  connectToApplications,
+            reverseReach
 
       // All the hidden attack steps below are hidden because they are just used for the internal mechanics of the ConnectionRules
+      | attemptReverseReach @hidden
+        developer info: "Intermediate attack step."
+        ->  reverseReach
+
+      & reverseReach @hidden
+        developer info: "Reverse reach is used to determine whether or not the attacker can be reached by the user."
+        ->  clientApplications().attemptReverseReach,
+            (networks \/ outNetworks).attemptReverseReach
+
       | attemptAccessNetworks @hidden
         developer info: "Intermediate attack step."
         ->  accessNetworks

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -467,6 +467,48 @@ category DataResources {
     {
       | attemptAccess
         user info: "The attacker is attempting to access the information."
+
+      | attemptRead @hidden
+        developer info: "Intermediate attack step."
+        ->  read
+
+      & read
+        user info: "Reading one replica allows the attacker to read all other replicas as well since the information contained in them is the same."
+        ->  dataBackups.read
+
+      | attemptWrite @hidden
+        developer info: "Intermediate attack step."
+        ->  write
+
+      & write
+        user info: "Data can be written only if replication has been broken."
+        -> dataBackups.write
+
+      | attemptDelete @hidden
+        developer info: "Intermediate attack step."
+        ->  delete
+
+      & delete
+        user info: "Data can be delete only if replication has been broken."
+        -> dataBackups.delete
+
+      | attemptDeny @hidden
+        developer info: "Intermediate attack step."
+        ->  deny
+
+      & deny
+        user info: "Data can be denied only if replication has been broken."
+        -> dataBackups.deny
+
+      & attemptBreakReplication @hidden
+        developer info: "Replication fails only if all of the backups have been compromised."
+        -> breakReplication
+
+      | breakReplication @hidden
+        developer info: "If all the replicas have been compromised it is possible to write, delete, or deny the data."
+        -> write,
+           delete,
+           deny
     }
 
     asset Data
@@ -496,10 +538,18 @@ category DataResources {
           <-  encryptCreds
           ->  accessUnencryptedData
 
+        !E dataReplicated @hidden
+          user info: "If the data are replicated then writing, deleting, or denying them requires disabling the replicas."
+          developer info: "Data will be considered as replicated if they have a Backup association with an Information asset."
+          <-  replicatedInformation
+          ->  unreplicatedWrite,
+              unreplicatedDelete,
+              unreplicatedDeny
+
         # authenticated
           user info: "If the data are authenticated, then modifying them is not possible to achieve."
           ->  containedData*.applicationRespondConnect,
-              containedData*.write,
+              containedData*.successfulWrite,
               containedData*.manInTheMiddle
 
         & accessUnencryptedData @hidden
@@ -513,9 +563,9 @@ category DataResources {
               applicationRespondConnect,
               eavesdrop,
               manInTheMiddle,
-              read,
-              write,
-              delete
+              successfulRead,
+              successfulWrite,
+              successfulDelete
 
         # dataNotPresent [Disabled]
           user info: "It should be used to model the probability of data actually not existing on the connected container (i.e. System, Application, Connection, etc.)."
@@ -537,7 +587,7 @@ category DataResources {
 
         | attemptRead @hidden
           user info: "Attempt to read the data."
-          ->  read
+          ->  successfulRead
 
         | identityAttemptRead @hidden
           user info: "Attempt to read the data through a compormised identity."
@@ -549,7 +599,7 @@ category DataResources {
 
         | attemptWrite @hidden
           user info: "Attempt to write on the data."
-          ->  write
+          ->  successfulWrite
 
         | identityAttemptWrite @hidden
           user info: "Attempt to write the data through a compormised identity."
@@ -561,7 +611,7 @@ category DataResources {
 
         | attemptDelete @hidden
            user info: "Attempt to delete the data."
-          -> delete
+          -> successfulDelete
 
         | identityAttemptDelete @hidden
           user info: "Attempt to delete the data through a compormised identity."
@@ -571,26 +621,65 @@ category DataResources {
           developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
           ->  attemptDelete
 
-        & read {C}
+        & successfulRead @hidden
+          developer info: "Intermediate attack step to model the requirements."
+          ->  read
+
+        | read {C}
           user info: "The attacker can read the data."
           ->  containedData.attemptRead,
-              readContainedInformation
+              readContainedInformation,
+              replicatedInformation.attemptRead
 
-        & write {I}
+        | breakReplication @hidden
+          developer info: "Intermediate attack step represent that this data asset no longer provides replication. This occurs if the data are written, deleted, or denied."
+          ->  replicatedInformation.attemptBreakReplication
+
+        & successfulWrite @hidden
+          developer info: "Intermediate attack step to model the requirements."
+          ->  replicatedInformation.attemptWrite,
+              breakReplication,
+              unreplicatedWrite
+
+        & unreplicatedWrite @hidden
+          developer info: "Intermediate attack step to be used if the data are not replicated."
+          ->  write
+
+        | write {I}
           user info: "The attacker can write to the location of the data, effectively modifying or deleting it."
           ->  containedData.attemptWrite,
               attemptDelete,
               compromiseAppOrigin
 
-        & delete {I,A}
+        & successfulDelete @hidden
+          developer info: "Intermediate attack step to model the requirements."
+          ->  replicatedInformation.attemptDelete,
+              breakReplication,
+              unreplicatedDelete
+
+        & unreplicatedDelete @hidden
+          developer info: "Intermediate attack step to be used if the data are not replicated."
+          ->  delete
+
+        | delete {I,A}
           user info: "The attacker can delete the data."
           ->  containedData.attemptDelete
 
         | attemptDeny @hidden
           developer info: "Intermediate attack step to only allow deny on data after only if 'dataNotPresent' defense is disabled."
+          ->  successfulDeny
+
+        & successfulDeny @hidden
+          developer info: "Intermediate attack step to model the requirements."
+          ->  replicatedInformation.attemptDeny,
+              breakReplication,
+              unreplicatedDeny
+
+        & unreplicatedDeny @hidden
+          developer info: "Intermediate attack step to be used if the data are not replicated."
           ->  deny
 
-        & deny {A}
+        | deny {A}
           user info: "If a DoS is performed data are denied, it has the same effects as deleting the data."
           ->  containedData.deny
 
@@ -1134,7 +1223,9 @@ associations {
   System           [system]            0..1 <-- DataHosting           --> *   [sysData]                Data
       user info: "A system can host data."
   Data             [containerData]        * <-- InfoContainment       --> *   [information]            Information
-      user info: "Data can contain information, as for example credentials." 
+      user info: "Data can contain information, as for example credentials."
+  Data             [dataBackups]          * <-- Backup                --> *   [replicatedInformation]  Information
+      user info: "Information can be replicated across multiple data assets that offer redundancy."
   Data             [encryptedData]        * <-- EncryptionCredentials --> 0..1[encryptCreds]           Credentials
       user info: "Encrypted data can be associated with the relevant encryption credentials."
   Data             [originData]        0..1 <-- Origin                --> 0..1[originSoftwareProduct]  SoftwareProduct

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -474,7 +474,7 @@ category DataResources {
 
       & read
         user info: "Reading one replica allows the attacker to read all other replicas as well since the information contained in them is the same."
-        ->  dataBackups.read
+        ->  dataReplicas.read
 
       | attemptWrite @hidden
         developer info: "Intermediate attack step."
@@ -482,7 +482,7 @@ category DataResources {
 
       & write
         user info: "Data can be written only if replication has been broken."
-        -> dataBackups.write
+        -> dataReplicas.write
 
       | attemptDelete @hidden
         developer info: "Intermediate attack step."
@@ -490,7 +490,7 @@ category DataResources {
 
       & delete
         user info: "Data can be delete only if replication has been broken."
-        -> dataBackups.delete
+        -> dataReplicas.delete
 
       | attemptDeny @hidden
         developer info: "Intermediate attack step."
@@ -498,10 +498,10 @@ category DataResources {
 
       & deny
         user info: "Data can be denied only if replication has been broken."
-        -> dataBackups.deny
+        -> dataReplicas.deny
 
       & attemptBreakReplication @hidden
-        developer info: "Replication fails only if all of the backups have been compromised."
+        developer info: "Replication fails only if all of the replicas have been compromised."
         -> breakReplication
 
       | breakReplication @hidden
@@ -540,7 +540,7 @@ category DataResources {
 
         !E dataReplicated @hidden
           user info: "If the data are replicated then writing, deleting, or denying them requires disabling the replicas."
-          developer info: "Data will be considered as replicated if they have a Backup association with an Information asset."
+          developer info: "Data will be considered as replicated if they have a Replica association with an Information asset."
           <-  replicatedInformation
           ->  unreplicatedWrite,
               unreplicatedDelete,
@@ -571,7 +571,7 @@ category DataResources {
           user info: "It should be used to model the probability of data actually not existing on the connected container (i.e. System, Application, Connection, etc.)."
           developer info: "This attack step is in series with the 'accessUnencryptedData' attack step because there is no reason to defend encrypted data (or deny them) if they do not exist..."
           ->  accessUnencryptedData,
-              deny
+              successfulDeny
 
         & readContainedInformation
           user info: "From the data, attempt to access also the contained information, if exists."
@@ -1224,7 +1224,7 @@ associations {
       user info: "A system can host data."
   Data             [containerData]        * <-- InfoContainment       --> *   [information]            Information
       user info: "Data can contain information, as for example credentials."
-  Data             [dataBackups]          * <-- Backup                --> *   [replicatedInformation]  Information
+  Data             [dataReplicas]          * <-- Replica                --> *   [replicatedInformation]  Information
       user info: "Information can be replicated across multiple data assets that offer redundancy."
   Data             [encryptedData]        * <-- EncryptionCredentials --> 0..1[encryptCreds]           Credentials
       user info: "Encrypted data can be associated with the relevant encryption credentials."

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -208,12 +208,16 @@ category ComputeResources {
         ->  networkConnectFromReverseTakeover
 
       | networkConnect
-        user info: "An attacker can connect to any network exposed application."
-        ->  networkAccess,
-            specificAccessFromNetworkConnection,
+        user info: "An attacker can connect to any network exposed application and attempt to authenticate or trigger vulnerabilities."
+        ->  networkConnectWithoutTriggeringVulnerabilities,
             attemptUseVulnerability, // Connection to all possible vulnerabilities that might be connected to the Application
             allVulnerabilities().networkAccessAchieved,
             softwareProductVulnerabilityNetworkAccessAchieved
+
+      | networkConnectWithoutTriggeringVulnerabilities @hidden
+        developer info: "This attack step is used if the network connection occurs via a filtered ConnectionRule, in which case the attacker can still authenticate, but they cannot trigger vulnerabilities."
+        ->  networkAccess,
+            specificAccessFromNetworkConnection
 
       | accessNetworkAndConnections
         user info: "An attacker is also possible to access the network(s) and connections to which this application is connected to, and perform client-side attacks."
@@ -1081,10 +1085,11 @@ category Networking {
       let clientApplications = (applications \/ outApplications)
       let serverApplications = (applications \/ inApplications)
 
-      # disabled [Disabled]
-        user info: "It should be used to model the probability that the connection rule is actually not existing."
+      # restricted [Disabled]
+        user info: "The restricted defence can be used to probabilistically model the likelihood of both the protocols required by the attack being enabled or the existence of the ConnectionRule altogether."
         ->  accessNetworks,
             connectToApplications,
+            connectToApplicationsWithoutTriggeringVulnerabilities,
             transmit,
             transmitResponse,
             denialOfService,
@@ -1093,10 +1098,9 @@ category Networking {
             allowWriteDataInTransit,
             allowDenyDataInTransit
 
-      # filtered [Disabled]
+      # payloadInspection [Disabled]
         user info: "If enabled, then the traffic is considered to be filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication (i.e. network-level vulnerabilities cannot be exploited)."
-        ->  transmit,
-            transmitResponse
+        ->  connectToApplications
 
       // All the hidden attack steps below are hidden because they are just used for the internal mechanics of the ConnectionRules
       | attemptAccessNetworks @hidden
@@ -1109,11 +1113,16 @@ category Networking {
 
       | attemptConnectToApplications @hidden
         developer info: "Intermediate attack step."
-        ->  connectToApplications
+        ->  connectToApplications,
+            connectToApplicationsWithoutTriggeringVulnerabilities
 
       & connectToApplications @hidden
         developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule."
         ->  serverApplications().networkConnect
+
+      & connectToApplicationsWithoutTriggeringVulnerabilities @hidden
+        developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule, but without triggering vulnerabilities on them. This attack step is used to allow legitimate traffic even when filtering is enabled on the connection."
+        ->  serverApplications().networkConnectWithoutTriggeringVulnerabilities
 
       | attemptTransmitResponse @hidden
         developer info: "Intermediate attack step."


### PR DESCRIPTION
The old filtered defence on the ConnectionRule made use of the automatic vulnerabilities which no longer exist.

This new version makes it so that vulnerabilities are not triggered and their network access requirements are not fulfilled when the attacker gains access to a filtered ConnectionRule.

The issue is that filtered defence is described as preventing malicious payloads on the connection in general. These deleterious data can also come via the unsafe actions of the user, the current implementation does not account for that. If we wish to remediate this issue we will need to have the unsafe action follow the ConnectionRules to see if any of them are filtered. This solution also comes with its own sets of problematic assumptions as we do not know which ConnectionRules lead to the potential attackers.

This conversation is also somewhat related to the potential viability of an Intrusion Detection and Prevention System(IDPS) asset #47.