### PR TITLE
Model Credentials that are involved in the authentication process.

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -489,8 +489,13 @@ category ComputeResources {
             appExecutedApps.attemptDeny
 
       & denyFromNetworkingAsset @hidden
-        user info: "This is an intermediate attack step to only allow deny on an application when all the connection rules and networks associated with it are denied, because an app can be serving on many different ports."
+        developer info: "This is an intermediate attack step to only allow deny on an application when all the connection rules and networks associated with it are denied, because an app can be serving on many different ports."
         ->  attemptDeny
+
+      & denyFromLockout @hidden
+        developer info: "This is an intermediate attack step to only allow deny on an application when all the executing identities are locked out."
+        ->  attemptDeny
+
     }
 
     asset IDPS extends Application
@@ -580,12 +585,14 @@ category DataResources {
       | write
         user info: "The attacker is able to write the information."
         ->  dataReplicas.write,
-            containerData.write
+            containerData.write,
+            delete
 
       | delete
         user info: "The attacker is able to delete the information."
         ->  dataReplicas.delete,
-            containerData.delete
+            containerData.delete,
+            deny
 
       | deny
         user info: "The attacker is able to deny the information."
@@ -843,6 +850,14 @@ category IAM {
         +>  parentId.attemptAssume,
             memberOf.attemptAssume,
             identityPrivileges.attemptAssume
+
+      & attemptLockout @hidden
+        developer info: "Only lockout an identity if all of the Credentials that could be used to authenticate have been denied."
+        ->  lockout
+
+      | lockout {A}
+        user info: "The identity has been locked out and cannot be used by legitimate users."
+        ->  execPrivApps.denyFromLockout
     }
 
     asset Privileges extends IAMObject
@@ -890,6 +905,14 @@ category IAM {
       | read @Override
         developer info: "If the attacker is able to read the information containing credentials we assume that they are compromised."
         +> attemptUse
+
+      | write @Override
+        developer info: "If the attacker is able to write the information containing credentials we assume that they have changed them for the authentication process."
+        +> attemptUse
+
+      | deny @Override
+        developer info: "If the attacker is able to deny the information containing credentials we assume that they have denied them for the authentication process."
+        +> identities.attemptLockout
 
       | useLeakedCredentials [EasyAndCertain]
         user info: "If the password/credential is leaked to some location, it can then be available to the attacker and therefore it can be used."


### PR DESCRIPTION
The `Credentials`asset was used to represent credentials being store or transmitted, but not credentials as part of the authentication process.

This pull request introduces the concept of overriding `Credentials` and locking out `Identities` when a `Credentials` asset is written or denied, respectively. This change requires a slightly different interpretation of the impact attack steps on the `Credentials` asset. If an attacker is able to write to `Credentials` the assumption is that they are able to change the information that the authentication process uses to verify if the credentials match, therefore if an attacker is able to write them over they can trivially assume the `Identities` associated with the credentials.

Similarly, if an attacker is able to deny `Credentials` the assumption is that they can prevent the authentication process from accepting the legitimate information provided by the authorised users. This leads to the newly introduced attack step on the `Identity` asset called `Lockout`. If all of the `Credentials` associated with an `Identity` are denied the `Lockout` attack step is triggered on the `Identity` to represent that users can no longer authenticate using that `Identity` due to the attacker's actions. Additionally, if all of the `Identities` that have `ExecutionPrivilegeAccess` on an `Application` have been locked out this leads to a `Deny` on the `Application`, it is assumed that there is no way for legitimate users to run it any longer. In some situations this would require a reboot or restart, but since one would occur sooner or later the deny is simply triggered trivially.

For situations where the attacker is able to `Write` or `Deny` `Data` that hold `Credentials`, but the `Data` are not seen as the actual information used by the authentication process, but rather separate entries, such as password managers or text files containing credentials, the `Replica` association between `Credentials` and `Data` should be used. If the user is assumed to be able to remember the `Credentials` a `Data` asset that represents the user's biological memory should be created and associated with the `Credentials` via the `Replica` relationship to prevent the attacker from locking out the user. This `Data` asset representing biological memory should, obviously, not be connected to any other asset as it simply resides in the user's brain.