### PR TITLE
Improve Credentials guessCredentials Functionality

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -820,6 +820,11 @@ category IAM {
       | lockout {A}
         user info: "The identity has been locked out and cannot be used by legitimate users."
         ->  execPrivApps.denyFromLockout
+
+      !E missingUser @hidden
+        developer info: "If there are no Users asociated with this Identity we make the worst case scenario assumption regarding the strength of the Credentials belonging to it."
+        <-  users
+        ->  credentials.weakCredentials
     }
 
     asset Privileges extends IAMObject
@@ -925,8 +930,13 @@ category IAM {
         user info: "The attacker is able to steal the credentials."
         ->  attemptUse
 
+      !E missingIdentity @hidden
+        developer info: "If there are no Identities asociated with these Credentials we make the worst case scenario assumption regarding the strength of the Credentials."
+        <-  identities
+        ->  weakCredentials
+
       | weakCredentials @hidden
-        developer info: "Intermediate step used to represent how weak the credentials the user employs are. This is inversely related to the securityAwareness defence on the User asset."
+        developer info: "Intermediate step used to represent how weak the credentials the user employs are. This is inversely related to the securityAwareness defence on the User asset associated with the Identity to which these Credentials belong. If either the User or Identity associations are missing the assumption is made that the crentials are weak and therefore guessable by the attacker."
         ->  guessCredentials,
             requiredFactors.weakCredentials
 
@@ -941,6 +951,7 @@ category IAM {
 
       & guessCredentials [HardAndUncertain]
         user info: "The attacker can attempt to just guess a set of credentials. The likelihood of succeeding is depend on how strong the credentials are."
+        modeller info: "The guessability of the Credentials is influenced by the notGuessable defence on this asset and the securityAwareness defence on the User associated with the Identity that these Credentials belong to. If either the User or Identity associations are missing the assumption is made that the crentials are guessable and only the notGuessable defence would play a role in restricting this attack step."
         developer info: "We should research the probability we want to use for this attack step more."
         ->  attemptUse
     }


### PR DESCRIPTION
An attacker can attempt to guess a set of credentials if the `NotGuessable` defence on the asset is disabled. The likelihood of succeeding in guessing them is based on the `SecurityAwareness` defence of the `User` associated with the `Identity` that uses the `Credentials` to represent that more security aware people tend to ensure they use stronger credentials, while more oblivious individuals are more careless and their credentials tend to be weaker and easier to guess.

However, this implementation means that if the `Credentials` are not associated with an `Identity` and/or the `Identity` to which the `Credentials` belong is not associated with a `User` we lack a `SecurityAwareness` defence to determine the strength of the credentials.

This pull request improves this behaviour by simply assuming that if the `Identity` or `User` in the `Credentials -> Identity -> User` chain are missing the `Credendials` are weak. This worst case scenario assumption means that models that want to represent the attacker guessing credentials, but in which the strength of those credentials is not particularly relevant, are simpler to implement.