### PR TITLE
Rework the IAMObject Abstract Asset to Extend Information

### DIFF
--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -859,7 +859,8 @@ category IAM {
             readPrivData.identityAttemptRead,
             writePrivData.identityAttemptWrite,
             deletePrivData.identityAttemptDelete,
-            managedIAMs.attemptAssume
+            managedIAMs.attemptAssume,
+            subprivileges.attemptAssume
 
       | deny
         user info: "Denying Identity, Group, or Privileges means that they are unavailable to legitimate users and which are locked out."
@@ -880,7 +881,8 @@ category IAM {
       | lockout {A}
         user info: "The Identity, Group, or Privileges has been locked out and cannot be used by legitimate users. This means that the applications that they can execute and data they can read might also be denied if all of the access roles that could execute or read them, respectively, have been locked out."
         ->  execPrivApps.denyFromLockout,
-            readPrivData.denyFromLockout
+            readPrivData.denyFromLockout,
+            subprivileges.lockout
     }
 
     asset Identity extends IAMObject
@@ -894,8 +896,7 @@ category IAM {
         user info: "After authentication or compromise of an account/identity, assume its privileges."
         developer info: "This is both legitimate and illegitimate access! Also assume all the privileges of the parent identities (on the above level/inherited by this identity) because those represent the group of (inherited) roles."
         +>  parentId.attemptAssume,
-            memberOf.attemptAssume,
-            identityPrivileges.attemptAssume
+            memberOf.attemptAssume
 
       & attemptLockoutFromCredentials @hidden
         developer info: "Only lockout an identity if all of the Credentials that could be used to authenticate have been denied."
@@ -918,8 +919,7 @@ category IAM {
       | assume @Override {C,I,A}
         user info: "After authentication or compromise of an account/identity, assume its privileges."
         developer info: "Assume identity/group the privileges are associated with since the privileges are simply an extension of it."
-        +>  privilegeIdentities.attemptAssume,
-            privilegeGroups.attemptAssume
+        +>  IAMOwners.attemptAssume
     }
 
     asset Group extends IAMObject
@@ -929,8 +929,7 @@ category IAM {
       | assume @Override {C,I,A}
         user info: "If an identity of a group is compromised then the whole group (i.e. all other privileges of the group) should be considered as compromised. Furthermore, the parent groups should also be considered compromised."
         developer info: "The parent groups should be compromised because all the privileges of the parent groups are inherited on the children groups but lower children groups should not be compromised because lower levels might have inherited plus additional privileges."
-        +>  parentGroup.attemptAssume,
-            groupPrivileges.attemptAssume
+        +>  parentGroup.attemptAssume
     }
 
     asset Credentials extends Information
@@ -1136,11 +1135,11 @@ category User {
         modeler info: "An attacker may trigger the assume step on identities belonging to the user without being able to reach (or be reached) via any of the Applications that the identity has access to. This represents an unmaterialised threat in that scenario. The choice of probability is entirely arbitrary and should be replaced with a scientifically grounded distribution."
         ->  userIds.attemptAssume,
             userIds.execPrivApps.attemptUnsafeUserActivity,
-            userIds.identityPrivileges.execPrivApps.attemptUnsafeUserActivity,
+            userIds.subprivileges.subprivileges*.execPrivApps.attemptUnsafeUserActivity,
             userIds.highPrivApps.attemptUnsafeUserActivity,
-            userIds.identityPrivileges.highPrivApps.attemptUnsafeUserActivity,
+            userIds.subprivileges.subprivileges*.highPrivApps.attemptUnsafeUserActivity,
             userIds.lowPrivApps.attemptUnsafeUserActivity,
-            userIds.identityPrivileges.lowPrivApps.attemptUnsafeUserActivity
+            userIds.subprivileges.subprivileges*.lowPrivApps.attemptUnsafeUserActivity
     }
 }
 
@@ -1477,9 +1476,10 @@ associations {
   IAMObject        [writingIAMs]          * <-- WritePrivileges       --> *    [writePrivData]          Data
   IAMObject        [deletingIAMs]         * <-- DeletePrivileges      --> *    [deletePrivData]         Data
   // Associations for the Privileges asset
-  Identity         [privilegeIdentities]  * <-- HasPrivileges         --> *    [identityPrivileges]     Privileges
-  Group            [privilegeGroups]      * <-- HasPrivileges         --> *    [groupPrivileges]        Privileges
-      user info: "Identities, Groups, and Privileges may have account management roles for other Identities, Groups, and Privileges."
+  IAMObject        [IAMOwners]            * <-- HasPrivileges         --> *    [subprivileges]          Privileges
+      user info: "Identities, Groups, and Privileges may have a subset of Privileges that we logically separate to model specific scenarios, such as partial lockouts or speculating about possible privileges."
+  // Self-referential associations for the IAMObject asset
   IAMObject        [managers]             * <-- AccountManagement     --> *    [managedIAMs]            IAMObject
+      user info: "Identities, Groups, and Privileges may have account management roles for other Identities, Groups, and Privileges."
 
 }

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -906,6 +906,10 @@ category IAM {
         developer info: "Intermediate attack step to model defences."
         ->  lockout
 
+      | lockout
+        user info: "If all of the Identities belonging to a Group are lockedout we assume that the Group as a whole is lockedout."
+        +>  memberOf.lockoutFromMembers
+
       !E missingUser @hidden
         developer info: "If there are no Users asociated with this Identity we make the worst case scenario assumption regarding the strength of the Credentials belonging to it."
         <-  users
@@ -930,6 +934,10 @@ category IAM {
         user info: "If an identity of a group is compromised then the whole group (i.e. all other privileges of the group) should be considered as compromised. Furthermore, the parent groups should also be considered compromised."
         developer info: "The parent groups should be compromised because all the privileges of the parent groups are inherited on the children groups but lower children groups should not be compromised because lower levels might have inherited plus additional privileges."
         +>  parentGroup.attemptAssume
+
+      & lockoutFromMembers @hidden
+        user info: "If all of the Identities belonging to a Group are lockedout we assume that the Group as a whole is lockedout."
+        ->  lockout
     }
 
     asset Credentials extends Information

--- a/src/main/mal/coreLang.mal
+++ b/src/main/mal/coreLang.mal
@@ -538,7 +538,7 @@ category ComputeResources {
         ->  attemptDeny
 
       & denyFromLockout @hidden
-        developer info: "This is an intermediate attack step to only allow deny on an application when all the executing identities are locked out."
+        developer info: "This is an intermediate attack step to only trigger deny on an application when all the executing access control roles are locked out."
         ->  attemptDeny
 
     }
@@ -809,6 +809,10 @@ category DataResources {
             information.deny,
             replicatedInformation.attemptDenyFromReplica
 
+      & denyFromLockout @hidden
+        developer info: "This is an intermediate attack step to only trigger deny on data when all the access control roles that can read them are locked out."
+        ->  attemptDeny
+
       | attemptReverseReach @hidden
         developer info: "Intermediate attack step."
         ->  reverseReach
@@ -831,12 +835,13 @@ category DataResources {
 
 category IAM {
 
-    abstract asset IAMObject
+    abstract asset IAMObject extends Information
       user info: "An IAM object represents the base logic shared by all assets used for Identity and Access Management roles(Identity, Group, Privileges)."
     {
       # disabled [Disabled]
         user info: "It should be used to model the probability that the IAM object does not actually exist."
-        ->  successfulAssume
+        ->  successfulAssume,
+            successfulLockout
 
       | attemptAssume
         user info: "Attempt to assume the privileges associated with the IAM object. If disabled this will not be possible."
@@ -855,12 +860,36 @@ category IAM {
             writePrivData.identityAttemptWrite,
             deletePrivData.identityAttemptDelete,
             managedIAMs.attemptAssume
+
+      | deny
+        user info: "Denying Identity, Group, or Privileges means that they are unavailable to legitimate users and which are locked out."
+        +>  attemptLockout
+
+      | write
+        user info: "Overwriting Identity, Group, or Privileges means that the attacker is able to assume them."
+        +>  attemptAssume
+
+      | attemptLockout @hidden
+        developer info: "Intermediate attack step."
+        ->  successfulLockout
+
+      & successfulLockout @hidden
+        developer info: "Intermediate attack step to model defences."
+        ->  lockout
+
+      | lockout {A}
+        user info: "The Identity, Group, or Privileges has been locked out and cannot be used by legitimate users. This means that the applications that they can execute and data they can read might also be denied if all of the access roles that could execute or read them, respectively, have been locked out."
+        ->  execPrivApps.denyFromLockout,
+            readPrivData.denyFromLockout
     }
 
     asset Identity extends IAMObject
       user info: "An identity models an IAM identity that should then be associated with privileges on other instances."
       developer info: "An identity can be visualised as a group of assumable roles that can be associated with many credentials."
     {
+      # disabled
+        +>  successfulLockoutFromCredentials
+
       | assume @Override {C,I,A}
         user info: "After authentication or compromise of an account/identity, assume its privileges."
         developer info: "This is both legitimate and illegitimate access! Also assume all the privileges of the parent identities (on the above level/inherited by this identity) because those represent the group of (inherited) roles."
@@ -868,13 +897,13 @@ category IAM {
             memberOf.attemptAssume,
             identityPrivileges.attemptAssume
 
-      & attemptLockout @hidden
+      & attemptLockoutFromCredentials @hidden
         developer info: "Only lockout an identity if all of the Credentials that could be used to authenticate have been denied."
-        ->  lockout
+        ->  successfulLockoutFromCredentials
 
-      | lockout {A}
-        user info: "The identity has been locked out and cannot be used by legitimate users."
-        ->  execPrivApps.denyFromLockout
+      & successfulLockoutFromCredentials @hidden
+        developer info: "Intermediate attack step to model defences."
+        ->  lockout
 
       !E missingUser @hidden
         developer info: "If there are no Users asociated with this Identity we make the worst case scenario assumption regarding the strength of the Credentials belonging to it."
@@ -935,7 +964,7 @@ category IAM {
 
       | deny @Override
         developer info: "If the attacker is able to deny the information containing credentials we assume that they have denied them for the authentication process."
-        +> identities.attemptLockout
+        +> identities.attemptLockoutFromCredentials
 
       | useLeakedCredentials [EasyAndCertain]
         user info: "If the password/credential is leaked to some location, it can then be available to the attacker and therefore it can be used."


### PR DESCRIPTION
Rework the `IAMObject` abstract asset to extend the `Information` asset and connect the attack steps that make sense.

- `IAMObject` `Deny` leads to `Lockout`.
- `IAMObject` `Write` leads to `Assume`.
- `IAMObject` `Lockout` leads to `Deny` on the `Data` is has `ReadPrivileges` for and on the `Applications` it has `ExecutionPrivileges` on. The other types of privileges `Write` and `Delete` on `Data` and `High` and `Low` on `Applications` were not seen as necessarily propagating the effects of a lockout. There may be circumstances where, for example, removing write privileges would impact the functionality of using the data. However, these are defined by the specific functionality of that `Data` asset and therefore beyond the scope of coreLang.
- Rework `Privileges` to serve as a subset for any `IAMObject` class, not just `Identity` and `Group`. This also allows the modeller to build `Privileges` hierarchies, I doubt it will be a commonly used feature, but it seemed like a more generic and cleaner design anyway.
- `Lockout` a whole `Group` if all of the member `Identities` have been locked out.