### PR TITLE
Rework Data in Data Attack Step Propagation

### DIFF
--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -285,10 +285,10 @@ category ComputeResources {
         ->  appExecutedApps.localConnect, // But also achieve localConnect on all child applications (this is something that needs to be reviewed again at a later stage)
             attemptLocalConnectVulnOnHost,
             attemptUseVulnerability,   // Connection to all possible vulnerabilities that might be connected to the Application
-            containedData.attemptAccessFromIdentity, // This also enables the use of compromised identities but only after specificAccess is reached
-            sentData.identityAttemptRead, // Both Data sent and received can be read
-            receivedData.identityAttemptRead,
-            sentData.identityAttemptWrite, // But only sent Data can be written
+            containedData.authorizedAccessFromApplication, // This also enables the use of compromised permissions but only after specificAccess is reached
+            sentData.authorizedReadFromApplication, // Both Data sent and received can be read
+            receivedData.authorizedReadFromApplication,
+            sentData.authorizedWriteFromApplication, // But only sent Data can be written
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections  // and access the network(s) and connections on/to which the app is connected
 

--- a/src/main/mal/DataResources.mal
+++ b/src/main/mal/DataResources.mal
@@ -97,7 +97,7 @@ category DataResources {
         ->  access
 
       | attemptAccessFromIdentity
-        user info: "Access the data through a compormised identity."
+        user info: "Access the data through a compromised identity."
         ->  identityRead,
             identityWrite,
             identityDelete
@@ -106,8 +106,7 @@ category DataResources {
         user info: "Access the data."
         ->  attemptRead,
             attemptWrite,
-            attemptDelete,
-            containedData.attemptAccess
+            attemptDelete
 
       !E dataEncrypted @hidden
         user info: "If the data are encrypted then accessing them requires the associated encryption credentials/key."
@@ -131,8 +130,8 @@ category DataResources {
 
       | accessSpoofedData @hidden
         user info: "Intermediate attack step to only allow effects of 'accessUnsignedData' on data after compromising the signing credentials or signing is disabled."
-        ->  containedData*.applicationRespondConnect,
-            containedData*.successfulWrite
+        ->  applicationRespondConnect,
+            successfulWrite
 
       | accessDecryptedData @hidden
         user info: "Intermediate attack step to only allow effects of 'accessUnencryptedData' on data after compromising the encryption credentials or encryption is disabled."

--- a/src/main/mal/DataResources.mal
+++ b/src/main/mal/DataResources.mal
@@ -96,11 +96,11 @@ category DataResources {
         user info: "Attempt to access the data, this might fail if the 'dataNotPresent' defense is used."
         ->  access
 
-      | attemptAccessFromIdentity
-        user info: "Access the data through a compromised identity."
-        ->  identityRead,
-            identityWrite,
-            identityDelete
+      | authorizedAccessFromApplication
+        user info: "Attempt to gain access to the data through permissions."
+        ->  authorizedReadFromApplication,
+            authorizedWriteFromApplication,
+            authorizedDeleteFromApplication
 
       & access
         user info: "Access the data."
@@ -164,38 +164,6 @@ category DataResources {
         user info: "Attempt to read the data."
         ->  successfulRead
 
-      | identityAttemptRead @hidden
-        user info: "Attempt to read the data through a compromised identity."
-        ->  identityRead
-
-      & identityRead @hidden
-        developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
-        ->  attemptRead
-
-      | attemptWrite @hidden
-        user info: "Attempt to write on the data."
-        ->  successfulWrite
-
-      | identityAttemptWrite @hidden
-        user info: "Attempt to write the data through a compromised identity."
-        ->  identityWrite
-
-      & identityWrite @hidden
-        developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
-        ->  attemptWrite
-
-      | attemptDelete @hidden
-         user info: "Attempt to delete the data."
-        -> successfulDelete
-
-      | identityAttemptDelete @hidden
-        user info: "Attempt to delete the data through a compromised identity."
-        ->  identityDelete
-
-      & identityDelete @hidden
-        developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
-        ->  attemptDelete
-
       & successfulRead @hidden
         developer info: "Intermediate attack step to model the requirements."
         ->  read
@@ -206,6 +174,22 @@ category DataResources {
             information.read,
             replicatedInformation.attemptReadFromReplica,
             extract
+
+      | authorizedReadFromIAM @hidden
+        user info: "The attacker has obtained the access control permissions required to read the data."
+        ->  authorizedRead
+
+      | authorizedReadFromApplication @hidden
+        user info: "The attacker can reach the data via an Application, but they still require the adequate permissions to read it."
+        ->  authorizedRead
+
+      & authorizedRead @hidden
+        developer info: "An attacker is able to read the Data through legitimate means, this requires both access to the Data and the adequate permissions."
+        ->  attemptRead
+
+      | attemptWrite @hidden
+        user info: "Attempt to write on the data."
+        ->  successfulWrite
 
       & successfulWrite @hidden
         developer info: "Intermediate attack step to model the requirements."
@@ -219,6 +203,22 @@ category DataResources {
             attemptDelete,
             compromiseAppOrigin
 
+      | authorizedWriteFromIAM @hidden
+        user info: "The attacker has obtained the access control permissions required to write the data."
+        ->  authorizedWrite
+
+      | authorizedWriteFromApplication @hidden
+        user info: "The attacker can reach the data via an Application, but they still require the adequate permissions to write it."
+        ->  authorizedWrite
+
+      & authorizedWrite @hidden
+        developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
+        ->  attemptWrite
+
+      | attemptDelete @hidden
+         user info: "Attempt to delete the data."
+        -> successfulDelete
+
       & successfulDelete @hidden
         developer info: "Intermediate attack step to model the requirements."
         ->  delete
@@ -229,6 +229,18 @@ category DataResources {
             information.delete,
             replicatedInformation.attemptDeleteFromReplica,
             attemptDeny
+
+      | authorizedDeleteFromIAM @hidden
+        user info: "The attacker has obtained the access control permissions required to delete the data."
+        ->  authorizedDelete
+
+      | authorizedDeleteFromApplication @hidden
+        user info: "The attacker can reach the data via an Application, but they still require the adequate permissions to delete it."
+        ->  authorizedDelete
+
+      & authorizedDelete @hidden
+        developer info: "Intermediate attack step to only allow operations on data after both access and identity assume is compromised."
+        ->  attemptDelete
 
       | attemptDeny @hidden
         developer info: "Intermediate attack step to only allow deny on data after only if 'dataNotPresent' defense is disabled."

--- a/src/main/mal/IAM.mal
+++ b/src/main/mal/IAM.mal
@@ -37,9 +37,9 @@ category IAM {
         ->  execPrivApps.authenticate,
             highPrivApps.authenticate,
             lowPrivApps.specificAccessAuthenticate,
-            readPrivData.identityAttemptRead,
-            writePrivData.identityAttemptWrite,
-            deletePrivData.identityAttemptDelete,
+            readPrivData.authorizedReadFromIAM,
+            writePrivData.authorizedWriteFromIAM,
+            deletePrivData.authorizedDeleteFromIAM,
             managedIAMs.attemptAssume,
             subprivileges.attemptAssume
 

--- a/src/test/java/org/mal_lang/corelang/test/DataTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataTest.java
@@ -33,9 +33,21 @@ public class DataTest extends CoreLangTest {
         attacker.attack();
 
         model.data1.access.assertCompromisedInstantaneously();
-        model.data2.access.assertCompromisedInstantaneously();
-        model.encdata.access.assertUncompromised();
-        model.notexistdata.access.assertUncompromised();
+        model.data1.read.assertCompromisedInstantaneously();
+        model.data1.write.assertCompromisedInstantaneously();
+        model.data1.delete.assertCompromisedInstantaneously();
+
+        model.data2.read.assertCompromisedInstantaneously();
+        model.data2.write.assertCompromisedInstantaneously();
+        model.data2.delete.assertCompromisedInstantaneously();
+
+        model.encdata.read.assertUncompromised();
+        model.encdata.write.assertUncompromised();
+        model.encdata.delete.assertUncompromised();
+
+        model.notexistdata.read.assertUncompromised();
+        model.notexistdata.write.assertUncompromised();
+        model.notexistdata.delete.assertUncompromised();
     }
 
     @Test
@@ -51,17 +63,14 @@ public class DataTest extends CoreLangTest {
         model.data1.write.assertUncompromised();
         model.data1.delete.assertUncompromised();
 
-        model.data2.access.assertUncompromised();
         model.data2.read.assertUncompromised();
         model.data2.write.assertUncompromised();
         model.data2.delete.assertUncompromised();
 
-        model.encdata.access.assertUncompromised();
         model.encdata.read.assertUncompromised();
         model.encdata.write.assertUncompromised();
         model.encdata.delete.assertUncompromised();
 
-        model.notexistdata.access.assertUncompromised();
         model.notexistdata.read.assertUncompromised();
         model.notexistdata.write.assertUncompromised();
         model.notexistdata.delete.assertUncompromised();
@@ -78,13 +87,21 @@ public class DataTest extends CoreLangTest {
         attacker.attack();
 
         model.data1.access.assertCompromisedInstantaneously();
-        model.data2.access.assertCompromisedInstantaneously();
-        model.encdata.access.assertCompromisedInstantaneously();
+        model.data1.read.assertCompromisedInstantaneously();
+        model.data1.write.assertCompromisedInstantaneously();
+        model.data1.delete.assertCompromisedInstantaneously();
+
+        model.data2.read.assertCompromisedInstantaneously();
+        model.data2.write.assertCompromisedInstantaneously();
+        model.data2.delete.assertCompromisedInstantaneously();
+
         model.encdata.read.assertCompromisedInstantaneously();
         model.encdata.write.assertCompromisedInstantaneously();
         model.encdata.delete.assertCompromisedInstantaneously();
 
-        model.notexistdata.access.assertUncompromised();
+        model.notexistdata.read.assertUncompromised();
+        model.notexistdata.write.assertUncompromised();
+        model.notexistdata.delete.assertUncompromised();
     }
 
 }

--- a/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
+++ b/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
@@ -103,11 +103,14 @@ public class IAMIntegrationTests extends CoreLangTest {
             network.access.assertCompromisedInstantaneously();
             application.networkConnect.assertCompromisedInstantaneously();
             identity.assume.assertCompromisedInstantaneously();
-            data.identityAttemptRead.assertCompromisedInstantaneously();
-            data.identityAttemptWrite.assertUncompromised();
-            data.identityAttemptDelete.assertUncompromised();
+            data.authorizedReadFromIAM.assertCompromisedInstantaneously();
+            data.authorizedWriteFromIAM.assertUncompromised();
+            data.authorizedDeleteFromIAM.assertUncompromised();
             data.attemptAccess.assertUncompromised();
-            data.attemptAccessFromIdentity.assertUncompromised();
+            data.authorizedAccessFromApplication.assertUncompromised();
+            data.authorizedReadFromApplication.assertUncompromised();
+            data.authorizedWriteFromApplication.assertUncompromised();
+            data.authorizedDeleteFromApplication.assertUncompromised();
             data.access.assertUncompromised();
             data.read.assertUncompromised();
             data.write.assertUncompromised();
@@ -115,7 +118,7 @@ public class IAMIntegrationTests extends CoreLangTest {
             data.deny.assertCompromisedInstantaneously(); //Because of network.denialOfService
         }
     }
-    
+
     @Test
     public void identityDataIAMTest() {
         printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());


### PR DESCRIPTION
There are multiple aspects to this pull request. Many of them are refactoring and having attack steps behave according to a common pattern, in this respect this pull request is very relevant as a template for the future #77 effort.

First, have attack steps on `Data` propagate to `Data` contained in `Data` based on the impact attack steps(`Read`, `Write`, `Delete`, and `Deny`) rather than propagating `Access`.

Second, as a result of the above mentioned change, a small bug was fixed that meant that `Data` contained in `Data` was not properly impacted if it was compromised via `SpecificAccess` and an `Identity` that provided the privileges.

Third, have the `Data` impact attack steps themselves propagate the disruption one level at a time rather than using the `*` recursion.

Fourth, rename the attack steps to fit the new `IAMObject` superclass concept from `Identity[Read|Write|Delete]` to `Authorized[Read|Write|Delete]`.