### PR TITLE
Implement Malware Worm Replication via User to Other Hardware Systems.

### DIFF
--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -24,13 +24,18 @@ category ComputeResources {
         ->  successfulUseVulnerability,
             bypassHardwareModificationsProtection
 
-      & successfulUseVulnerability @ hidden
+      & successfulUseVulnerability @hidden
         developer info: "Intermediate attack step to enable defences."
         ->  useVulnerability
 
       | useVulnerability
         user info: "The attacker is able to use the connected vulnerabilities, usually as a result of obtaining physical access."
         ->  vulnerabilities.attemptAbuse
+
+      | spreadWormViaRemovableMedia @hidden
+        developer info: "Attempt to spread malware via removable media that the users connect to the hardware system."
+        ->  users.attemptDeliverMaliciousRemovableMedia,
+            physicalZones.users.attemptDeliverMaliciousRemovableMedia
 
       | attemptFullAccess @hidden
         developer info: "Intermediate attack step to allow for defences."
@@ -43,7 +48,8 @@ category ComputeResources {
       | fullAccess {C,I,A}
         user info: "Full access on a piece of hardware confers full access on the applications running on it and access to the hosted data."
         ->  sysExecutedApps.fullAccess,
-            hostedData.attemptAccess
+            hostedData.attemptAccess,
+            spreadWormViaRemovableMedia
 
       | attemptSupplyChainAttack
         developer info: "Intermediate attack step to allow for the auditing defence."
@@ -334,6 +340,7 @@ category ComputeResources {
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
             managedRoutingFw.attemptModify, // if the routing firewall manager app is compromised the routing firewall should also be compromised
+            hostHardware.spreadWormViaRemovableMedia, // Propagate malware worms via removable media
             specificAccess // And also provide specificAccess, mainly for completeness and more intuitive results
 
       | physicalAccessAchieved @hidden

--- a/src/main/mal/User.mal
+++ b/src/main/mal/User.mal
@@ -23,6 +23,10 @@ category User {
         user info: "If one credential of that user is compromised there is a probability that all other credentials of that user are also compromised."
         ->  passwordReuseCompromise
 
+      # noRemovableMediaUsage [Enabled]
+        user info: "The user does not utilise removable media and therefore the attack steps associated with it cannot be reached."
+        ->  successfulDeliverMaliciousRemovableMedia
+
       # securityAwareness
         user info: "The security awareness of the user makes it less likely that social engineering would be successful and reduces the likelihood that the user will engage in unsafe behaviour."
         ->  securityAwarenessBypassed,


### PR DESCRIPTION
Have `FullAccess` on an `Application` spread `UnsafeUserActivity` to other `Hardware` systems via a `User` that has physical access to them.

This is made to represent the concept that malware worms can spread themselves to other `Hardware` systems via removable media. Because this uses the existing `DeliverMaliciousRemovableMedia` attack step on the `User` the malware does not trivially spread to the other machines that the `User` has access to, which is likely to be apt given that it is unreliable in practice to wait for `Users` to connect removable drives to specific systems.

If the specific scenario involves reliable transmission via media drives the `Dependence` association introduced in #86 can be used.