### PR TITLE
Rework Network Connectivity into Separate Inspected and Uninspected Components

### DIFF
--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -248,24 +248,37 @@ category ComputeResources {
             allVulnerabilities().localAccessAchieved,
             softwareProductVulnerabilityLocalAccessAchieved
 
-      | networkConnect
+      | networkConnectUninspected
         user info: "An attacker can connect to any network exposed application and attempt to authenticate or trigger vulnerabilities."
-        ->  networkConnectWithoutTriggeringVulnerabilities,
-            attemptUseVulnerability, // Connection to all possible vulnerabilities that might be connected to the Application
+        ->  attemptUseVulnerability, // Connection to all possible vulnerabilities that might be connected to the Application
             allVulnerabilities().networkAccessAchieved,
-            softwareProductVulnerabilityNetworkAccessAchieved
+            softwareProductVulnerabilityNetworkAccessAchieved,
+            networkConnect,
+            specificAccessNetworkConnect
 
-      | networkConnectWithoutTriggeringVulnerabilities @hidden
-        developer info: "This attack step is used if the network connection occurs via a ConnectionRule that has its payload inspected, in which case the attacker can still authenticate, but they cannot trigger vulnerabilities."
-        ->  networkAccess,
-            specificAccessFromNetworkConnection
+
+      | networkConnectInspected
+        user info: "This attack step is used if the network connection occurs via a ConnectionRule that has its payload inspected, in which case the attacker can still authenticate, but they cannot trigger vulnerabilities."
+        ->  networkConnect,
+            specificAccessNetworkConnect
+
+      | networkConnect @hidden
+        user info: "Intermediate attack step."
+        ->  networkAccess
+
+      | specificAccessNetworkConnect
+        ->  specificAccessFromNetworkConnection
 
       | accessNetworkAndConnections
         user info: "An attacker is also possible to access the network(s) and connections to which this application is connected to, and perform client-side attacks."
-        ->  networks.access,
-            clientAccessNetworks.access,
-            clientApplicationConnections().attemptConnectToApplications,
-            clientApplicationConnections().attemptAccessNetworks
+        ->  networks.accessUninspected,
+            networks.accessInspected,
+            clientAccessNetworks.accessUninspected,
+            clientAccessNetworks.accessInspected,
+            clientApplicationConnections().attemptConnectToApplicationsUninspected,
+            clientApplicationConnections().attemptConnectToApplicationsInspected,
+            clientApplicationConnections().attemptAccessNetworksUninspected,
+            clientApplicationConnections().attemptAccessNetworksInspected
 
       | attemptNetworkConnectViaResponse
         developer info: "Intermediate attack step to handle defences."
@@ -275,7 +288,7 @@ category ComputeResources {
         user info: "An attacker may be able to respond to requests submitted by a client application."
         developer info: "Adopted from awsLang."
         modeler info: "The probability and its value are just estimations and are subject to change."
-        ->  networkConnect
+        ->  networkConnectUninspected
 
       & specificAccessFromLocalConnection @hidden
         developer info: "This intermediate step is used to represent that localConnect has happened before being able to get 'specificAccess'. Same as 'localAccess' attack step."
@@ -363,7 +376,7 @@ category ComputeResources {
       | unsafeUserActivity
         user info: "The unsafe actions of users on this application open it up to attacks and enable vulnerabilities that require user interaction."
         ->  localConnect,
-            networkConnect,
+            networkConnectUninspected,
             allVulnerabilities().userInteractionAchieved
 
       | attackerUnsafeUserActivityCapability @hidden

--- a/src/main/mal/Networking.mal
+++ b/src/main/mal/Networking.mal
@@ -29,7 +29,8 @@ category Networking {
       | physicalAccess {C, A}
         developer info: "Attacker has physical access on the network. This means he can cut wires/fibers, connect using iLOs, eavesdrop and get proper network access."
         ->  denialOfService,
-            attemptAccess,
+            attemptAccessUninspected,
+            attemptAccessInspected,
             bypassEavesdropDefenseViaPhysicalAccess,
             bypassManInTheMiddleDefenseViaPhysicalAccess
 
@@ -54,26 +55,44 @@ category Networking {
 
       | accessControlBypassed @hidden
         developer info: "Access control is bypassed either because it was not set, the attacker was able to circumvent it through additional effort."
-        ->  successfulAccess
+        ->  successfulAccessUninspected,
+            successfulAccessInspected
 
-      | attemptAccess @hidden
+      | attemptAccessUninspected @hidden
         user info: "Access on a Network can be attempted after physicalAccess."
-        ->  successfulAccess,
+        ->  successfulAccessUninspected,
             bypassAccessControl
 
-      & successfulAccess @hidden
-        developer info: "This is an intermediate attack step to prevent repeating code."
-        ->  access
+      | attemptAccessInspected @hidden
+        user info: "Access on a Network can be attempted after physicalAccess."
+        ->  successfulAccessInspected,
+            bypassAccessControl
 
-      | access
-        user info: "Access provides connect to all reachable applications."
-        ->  allowedApplicationConnections().attemptConnectToApplications,
-            applications.networkConnect,
+      & successfulAccessUninspected @hidden
+        developer info: "This is an intermediate attack step to prevent repeating code."
+        ->  accessUninspected
+
+      & successfulAccessInspected @hidden
+        developer info: "This is an intermediate attack step to prevent repeating code."
+        ->  accessInspected
+
+      | accessUninspected
+        user info: "Uninspected access provides connect to all reachable applications without any restrictions."
+        ->  allowedApplicationConnections().attemptConnectToApplicationsUninspected,
+            applications.networkConnectUninspected,
+            networkForwardingUninspected,
+            attemptReverseReach,
             clientApplications.attemptNetworkConnectViaResponse,
             accessNetworkData,
-            networkForwarding,
-            denialOfService,
-            attemptReverseReach
+            denialOfService
+
+      | accessInspected
+        user info: "Inspected access provides connect to all reachable applications, but with limitations."
+        ->  allowedApplicationConnections().attemptConnectToApplicationsInspected,
+            applications.networkConnectInspected,
+            networkForwardingInspected,
+            accessNetworkData,
+            denialOfService
 
       | attemptReverseReach @hidden
         developer info: "Intermediate attack step."
@@ -85,10 +104,16 @@ category Networking {
             clientApplications.attemptReverseReach,
             applications.attemptReverseReach
 
-      | networkForwarding
-        developer info: "By using the allowed connections (connection rules), forwarding from one network to another network or applications can happen."
-          ->  allowedNetworkConnections().attemptAccessNetworks,
-              allowedNetworkConnections().attemptConnectToApplications
+      | networkForwardingUninspected
+        developer info: "By using the allowed connections (connection rules), uninspected forwarding from one network to another network or applications can happen."
+          ->  allowedNetworkConnections().attemptAccessNetworksUninspected,
+              allowedNetworkConnections().attemptConnectToApplicationsUninspected,
+              networkForwardingInspected
+
+      | networkForwardingInspected
+        developer info: "By using the allowed connections (connection rules), inspected forwarding from one network to another network or applications can happen."
+          ->  allowedNetworkConnections().attemptAccessNetworksInspected,
+              allowedNetworkConnections().attemptConnectToApplicationsInspected
 
       | denialOfService {A}
         user info: "If a DoS is performed it affects, the applications communicating over the network as well as the connected application."
@@ -165,8 +190,8 @@ category Networking {
 
       | fullAccess {I, A}
         developer info: "If full access is achieved on RoutingFirewall then it is 0wned and all connections can be allowed! This can happen by compromising the manager application."
-        +>  (connectionRules.networks \/ connectionRules.outNetworks \/ connectionRules.inNetworks \/ connectionRules.diodeInNetworks).access,
-            connectionRules.applications.networkConnect
+        +>  (connectionRules.networks \/ connectionRules.outNetworks \/ connectionRules.inNetworks \/ connectionRules.diodeInNetworks).accessUninspected,
+            connectionRules.applications.networkConnectUninspected
     }
 
     asset ConnectionRule
@@ -188,14 +213,15 @@ category Networking {
 
       | restrictedBypassed @hidden
         developer info: "The restricted defense is bypassed either because it was not set, the attacker was able to circumvent it through additional effort."
-        ->  successfulAccessNetworks,
-            connectToApplications,
-            connectToApplicationsWithoutTriggeringVulnerabilities,
+        ->  successfulAccessNetworksUninspected,
+            successfulAccessNetworksInspected,
+            connectToApplicationsUninspected,
+            connectToApplicationsInspected,
             denialOfService,
             reverseReach
 
       # payloadInspection [Disabled]
-        user info: "If enabled, then the traffic is considered to be inspected and filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication(i. e. network-level vulnerabilities cannot be exploited)."
+        user info: "If enabled, then the traffic is considered to be inspected and filtered by an IDPS that can detect and stop malicious payloads, effectively allowing only legitimate communication(i. e. network-level vulnerabilities cannot be exploited, unsafe actions that the user may taken that would benefit the attacker are also prevented)."
         ->  payloadInspectionBypassed
 
       | bypassPayloadInspection [VeryHardAndUncertain]
@@ -205,7 +231,8 @@ category Networking {
 
       | payloadInspectionBypassed @hidden
         developer info: "Payload inspection is bypassed either because it was not set, the attacker was able to circumvent it through additional effort."
-        ->  connectToApplications,
+        ->  successfulAccessNetworksUninspected,
+            connectToApplicationsUninspected,
             reverseReach
 
       // All the hidden attack steps below are hidden because they are just used for the internal mechanics of the ConnectionRules
@@ -220,33 +247,54 @@ category Networking {
         ->  clientApplications().attemptReverseReach,
             (networks \/ outNetworks).attemptReverseReach
 
-      | attemptAccessNetworks @hidden
+      | attemptAccessNetworksUninspected @hidden
         developer info: "Intermediate attack step."
-        ->  successfulAccessNetworks,
+        ->  successfulAccessNetworksUninspected,
             bypassRestricted
 
-      & successfulAccessNetworks @hidden
-        developer info: "Intermediate attack step to model defences."
-        ->  accessNetworks
-
-      | accessNetworks
-        developer info: "Access all networks that are associated with this ConnectionRule."
-        ->  (networks  \/ inNetworks  \/ diodeInNetworks).access
-
-      | attemptConnectToApplications @hidden
+      | attemptAccessNetworksInspected @hidden
         developer info: "Intermediate attack step."
-        ->  connectToApplications,
-            connectToApplicationsWithoutTriggeringVulnerabilities,
+        ->  successfulAccessNetworksInspected,
+            bypassRestricted
+
+      & successfulAccessNetworksUninspected @hidden
+        developer info: "Intermediate attack step to model defences."
+        ->  accessNetworksUninspected
+
+      & successfulAccessNetworksInspected @hidden
+        developer info: "Intermediate attack step to model defences."
+        ->  accessNetworksInspected
+
+      | accessNetworksUninspected
+        developer info: "Access all networks that are associated with this ConnectionRule, without any restriction due to inspection."
+        ->  (networks  \/ inNetworks  \/ diodeInNetworks).accessUninspected,
+            accessNetworksInspected
+
+      | accessNetworksInspected
+        developer info: "Access all networks that are associated with this ConnectionRule, but taking into account that the traffic payload is being inspected."
+        ->  (networks  \/ inNetworks  \/ diodeInNetworks).accessInspected
+
+      | attemptConnectToApplicationsUninspected @hidden
+        developer info: "Intermediate attack step."
+        ->  connectToApplicationsUninspected,
             bypassRestricted,
             bypassPayloadInspection
 
-      & connectToApplications @hidden
-        developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule."
-        ->  serverApplications().networkConnect
+      | attemptConnectToApplicationsInspected @hidden
+        developer info: "Intermediate attack step."
+        ->  connectToApplicationsInspected,
+            bypassRestricted,
+            bypassPayloadInspection
 
-      & connectToApplicationsWithoutTriggeringVulnerabilities @hidden
-        developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule, but without triggering vulnerabilities on them. This attack step is used to allow legitimate traffic even when payload inspection is enabled on the connection."
-        ->  serverApplications().networkConnectWithoutTriggeringVulnerabilities
+      & connectToApplicationsUninspected @hidden
+        developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule, without any restriction due to inspection."
+        ->  serverApplications().networkConnectUninspected,
+            serverApplications().networkConnectInspected
+
+
+      & connectToApplicationsInspected @hidden
+        developer info: "Connect to all the (server) Applications that are associated with this ConnectionRule, but taking into account that the traffic payload is being inspected. This attack step is used to allow legitimate traffic even when payload inspection is enabled on the connection."
+        ->  serverApplications().networkConnectInspected
 
       | attemptDenialOfService @hidden
         developer info: "Intermediate attack step."

--- a/src/main/mal/Networking.mal
+++ b/src/main/mal/Networking.mal
@@ -21,10 +21,10 @@ category Networking {
       developer info: "The network asset tries to cover all the levels of the OSI stack in a very abstract and compact way (i.e. it tries to represent all the OSI layers). For example it will try to cover both ARP attacks (that are Level 2) but also DNS/HTTP spoofing attacks (that are Level 7)."
     {
       let allNetApplications = (clientApplications \/ applications)
-      let allowedNetworkConnections =  netConnections \/ outgoingNetConnections
-      let allowedApplicationConnections = (netConnections \/ outgoingNetConnections)
-      let allNetConnections = netConnections \/ ingoingNetConnections \/ outgoingNetConnections \/ diodeIngoingNetConnections
-      let allowedApplicationConnectionsApplications = allNetApplications() \/ allNetConnections().applications
+      let outboundAllowedConnections = (netConnections \/ outgoingNetConnections)
+      let inboundAllowedConnections = (netConnections \/ ingoingNetConnections \/ diodeIngoingNetConnections)
+      let allNetConnections = (netConnections \/ ingoingNetConnections \/ outgoingNetConnections \/ diodeIngoingNetConnections)
+      let allowedApplicationConnectionsApplications = (allNetApplications() \/ allNetConnections().applications)
 
       | physicalAccess {C, A}
         developer info: "Attacker has physical access on the network. This means he can cut wires/fibers, connect using iLOs, eavesdrop and get proper network access."
@@ -78,7 +78,7 @@ category Networking {
 
       | accessUninspected
         user info: "Uninspected access provides connect to all reachable applications without any restrictions."
-        ->  allowedApplicationConnections().attemptConnectToApplicationsUninspected,
+        ->  outboundAllowedConnections().attemptConnectToApplicationsUninspected,
             applications.networkConnectUninspected,
             networkForwardingUninspected,
             attemptReverseReach,
@@ -88,7 +88,7 @@ category Networking {
 
       | accessInspected
         user info: "Inspected access provides connect to all reachable applications, but with limitations."
-        ->  allowedApplicationConnections().attemptConnectToApplicationsInspected,
+        ->  outboundAllowedConnections().attemptConnectToApplicationsInspected,
             applications.networkConnectInspected,
             networkForwardingInspected,
             accessNetworkData,
@@ -106,14 +106,14 @@ category Networking {
 
       | networkForwardingUninspected
         developer info: "By using the allowed connections (connection rules), uninspected forwarding from one network to another network or applications can happen."
-          ->  allowedNetworkConnections().attemptAccessNetworksUninspected,
-              allowedNetworkConnections().attemptConnectToApplicationsUninspected,
+          ->  outboundAllowedConnections().attemptAccessNetworksUninspected,
+              outboundAllowedConnections().attemptConnectToApplicationsUninspected,
               networkForwardingInspected
 
       | networkForwardingInspected
         developer info: "By using the allowed connections (connection rules), inspected forwarding from one network to another network or applications can happen."
-          ->  allowedNetworkConnections().attemptAccessNetworksInspected,
-              allowedNetworkConnections().attemptConnectToApplicationsInspected
+          ->  outboundAllowedConnections().attemptAccessNetworksInspected,
+              outboundAllowedConnections().attemptConnectToApplicationsInspected
 
       | denialOfService {A}
         user info: "If a DoS is performed it affects, the applications communicating over the network as well as the connected application."

--- a/src/test/java/org/mal_lang/corelang/test/ApplicationTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/ApplicationTest.java
@@ -60,7 +60,7 @@ public class ApplicationTest extends CoreLangTest {
         var model = new ApplicationTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.application.networkConnect);
+        model.addAttacker(attacker,model.application.networkConnectUninspected);
         model.addAttacker(attacker,model.application.authenticate);
         attacker.attack();
 
@@ -78,7 +78,7 @@ public class ApplicationTest extends CoreLangTest {
         var model = new ApplicationTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.application.networkConnect);
+        model.addAttacker(attacker,model.application.networkConnectUninspected);
         model.addAttacker(attacker,model.application.specificAccessAuthenticate);
         attacker.attack();
 

--- a/src/test/java/org/mal_lang/corelang/test/DataInTransitTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataInTransitTest.java
@@ -70,7 +70,7 @@ public class DataInTransitTest extends CoreLangTest {
         var model = new DataInTransitTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.netA.attemptAccess);
+        model.addAttacker(attacker,model.netA.attemptAccessUninspected);
         attacker.attack();
 
         model.dataIn.read.assertCompromisedInstantaneously();
@@ -86,7 +86,7 @@ public class DataInTransitTest extends CoreLangTest {
         var model = new DataInTransitTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.netB.attemptAccess);
+        model.addAttacker(attacker,model.netB.attemptAccessUninspected);
         attacker.attack();
 
         model.dataIn.read.assertUncompromised();
@@ -95,5 +95,4 @@ public class DataInTransitTest extends CoreLangTest {
         model.dataOut.read.assertCompromisedInstantaneously();
         model.dataOut.write.assertCompromisedInstantaneously();
     }
-
 }

--- a/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
@@ -59,7 +59,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(true, false, false, false);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -79,7 +79,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(false, true, false, false);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -100,7 +100,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(false, false, true, false);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -122,7 +122,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(true, false, false, true);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -142,7 +142,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(false, true, false, true);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -163,7 +163,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new ApplicationToDataModel(false, false, true, true);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.app.networkConnect);
+        model.addAttacker(attacker, model.app.networkConnectUninspected);
         model.addAttacker(attacker, model.anyone.assume);
         attacker.attack();
 
@@ -210,7 +210,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new NetworkToDataModel(false);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.network.access);
+        model.addAttacker(attacker, model.network.accessUninspected);
         attacker.attack();
 
         model.outerData.read.assertCompromisedInstantaneously();
@@ -230,7 +230,7 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new NetworkToDataModel(true);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.network.access);
+        model.addAttacker(attacker, model.network.accessUninspected);
         attacker.attack();
 
         model.outerData.read.assertCompromisedInstantaneously();

--- a/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
+++ b/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
@@ -95,13 +95,13 @@ public class IAMIntegrationTests extends CoreLangTest {
 
         public void addAttacker(Attacker attacker) {
             attacker.addAttackPoint(identity.assume);
-            attacker.addAttackPoint(network.access);
+            attacker.addAttackPoint(network.accessUninspected);
         }
 
         public void assertModel() {
             // Make assertions
-            network.access.assertCompromisedInstantaneously();
-            application.networkConnect.assertCompromisedInstantaneously();
+            network.accessUninspected.assertCompromisedInstantaneously();
+            application.networkConnectUninspected.assertCompromisedInstantaneously();
             identity.assume.assertCompromisedInstantaneously();
             data.authorizedReadFromIAM.assertCompromisedInstantaneously();
             data.authorizedWriteFromIAM.assertUncompromised();

--- a/src/test/java/org/mal_lang/corelang/test/NetworkIntegrationTests.java
+++ b/src/test/java/org/mal_lang/corelang/test/NetworkIntegrationTests.java
@@ -42,15 +42,15 @@ public class NetworkIntegrationTests extends CoreLangTest {
         }
 
         public void addAttacker(Attacker attacker) {
-            attacker.addAttackPoint(netA.access);
+            attacker.addAttackPoint(netA.accessUninspected);
         }
 
         public void assertModel() {
             // Make assertions
-            netB.access.assertCompromisedInstantaneously();
-            netC.access.assertUncompromised();
-            netD.access.assertCompromisedInstantaneously();
-            app1.networkConnect.assertCompromisedInstantaneously();
+            netB.accessUninspected.assertCompromisedInstantaneously();
+            netC.accessUninspected.assertUncompromised();
+            netD.accessUninspected.assertCompromisedInstantaneously();
+            app1.networkConnectUninspected.assertCompromisedInstantaneously();
             routingfw.attemptUseVulnerability.assertUncompromised();
             routingfw.fullAccess.assertUncompromised();
         }
@@ -105,15 +105,15 @@ public class NetworkIntegrationTests extends CoreLangTest {
         }
 
         public void addAttacker(Attacker attacker) {
-          attacker.addAttackPoint(routingfw.networkConnect);
-          attacker.addAttackPoint(netA.access);
+          attacker.addAttackPoint(routingfw.networkConnectUninspected);
+          attacker.addAttackPoint(netA.accessUninspected);
         }
 
         public void assertModel() {
          // Make assertions
-         netA.access.assertCompromisedInstantaneously();
-         netB.access.assertCompromisedInstantaneously();
-         netC.access.assertCompromisedInstantaneously();
+         netA.accessUninspected.assertCompromisedInstantaneously();
+         netB.accessUninspected.assertCompromisedInstantaneously();
+         netC.accessUninspected.assertCompromisedInstantaneously();
          routingfw.attemptUseVulnerability.assertCompromisedInstantaneously();
          routingfw.fullAccess.assertCompromisedInstantaneously();
         }
@@ -132,5 +132,5 @@ public class NetworkIntegrationTests extends CoreLangTest {
       // Assert model
       model.assertModel();
     }
-    
+
 }


### PR DESCRIPTION
This pull request came about due to a bug where `payloadInspection` on a `ConnectionRule` would only propagate the restrictions to the attacker's actions to the `Applications` directly associated with it and not across other `Networking` assets.

The inspection discussed here refers to payload inspection of the traffic and not host/port-based filtering which is accounted for by the `Restricted` defence, instead.

The changes subsumed here separate all network connectivity in coreLang into two separate components:

- Uninspected communications which do not impose any limitations on the attacker's activities.
- Inspected communications which carry some limitations. Such as, preventing the attacker from exploiting `SoftwareVulnerabilities`, and limiting `ReverseReach`(which in turn is needed to maximise the impact of `UnsafeUserActivity` and prevent `Extract` on `Data`).

It is important that whenever the attacker is able to gain Uninspected networking reach to an asset that they are also flagged as having Inspected reach as well, otherwise some odd results might be produced.