### PR TITLE
Have Data Encryption Bypass PayloadInspection

### DIFF
--- a/src/main/mal/DataResources.mal
+++ b/src/main/mal/DataResources.mal
@@ -122,6 +122,16 @@ category DataResources {
         <-  signingCreds
         ->  accessUnsignedData
 
+      E payloadInspectionBypassViaEncryptedData
+        user info: "If the data are encrypted then payload inspection cannot be performed on the connection rules they are transmitted over."
+        <-  encryptCreds
+        ->  bypassPayloadInspectionViaEncryptedData
+
+      | bypassPayloadInspectionViaEncryptedData @hidden
+        developer info: "The connection rules that the encrypted data traverse over cannot provide payload inspection since they are assumed to permit encrypted traffic. This implies that the attacker could simply encrypt their own communications to evade inspection."
+        ->  (senderApp.clientApplicationConnections() /\ transitNetwork.inboundAllowedConnections()).payloadInspectionBypassed,
+            (receiverApp.serverApplicationConnections() /\ transitNetwork.outboundAllowedConnections()).payloadInspectionBypassed
+
       & accessUnencryptedData @hidden
         user info: "If data are unencrypted then access them."
         ->  accessDecryptedData


### PR DESCRIPTION
This pull request makes it so that `Data` that are encrypted via `Credentials` lead to bypassing the `PayloadInspection` defence on the `ConnectionRules` they could be traversing.

The assumption is that the `ConnectionRule` needs to allow for encrypted traffic and therefore the attacker could also just encrypt their sessions to elude payload inspection.

The current implementation only works for `ConnectionRules` that have an association to a receiving/sending `Application`. Determining whether a `ConnectionRule` that bridges only `Networks` is used by a specific `Data` asset is not impossible, but very cumbersome, so for the time being this was not implemented.

A workaround can be used in the meantime where a dummy `Application` that matches the directionality of the traffic can be added to the `ConnectionRules` that is used to just to determine if the `payloadInspection` should be bypassed or not.