### PR TITLE
Fix Data read, modify, deny from Application access

### DIFF
--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -305,7 +305,7 @@ category ComputeResources {
         ->  appExecutedApps.localConnect, // An attacker with low-privilege access on the executing instance is assumed to be able to locally interact with the executed applications.
             specificAccessRead,
             specificAccessModify,
-            specificAccessDeny,
+            specificAccessDelete,
             bypassContainerization,
             attemptUseVulnerability, // Attempt to exploit all the vulnerabilities associated with the Application
             attemptApplicationRespondConnectThroughData,
@@ -552,10 +552,10 @@ category ComputeResources {
             appExecutedApps.attemptDeny,
             sentData.attemptDeny // Sent Data can also be denied
 
-      | specificAccessDeny {A}
-        user info: "The attacker can deny some or all functionality and data pertaining to this application/service as well as executed applications, given the necessary permissions"
+      | specificAccessDelete {A}
+        user info: "The attacker can delete some or all functionality and data pertaining to this application/service as well as executed applications, given the necessary permissions"
         ->  containedData.authorizedDeleteFromApplication,
-            sentData.authorizedDeleteFromApplication // Sent Data can be denied given the necessary permissions
+            sentData.authorizedDeleteFromApplication // Sent Data can be deleted given the necessary permissions
 
       & denyFromNetworkingAsset @hidden
         developer info: "This is an intermediate attack step to only allow deny on an application when all the connection rules and networks associated with it are denied, because an app can be serving on many different ports."

--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -346,9 +346,7 @@ category ComputeResources {
             appExecutedApps.attemptModify, // Gain access on all applications executed by this (host) application
             executionPrivIAMs.attemptAssume,  // Assume also the execution privilege identities of this application to the access to the entire execution context
             containedData.attemptAccess,  // and access on all the contained data
-            sentData.attemptRead, // Both Data sent and received can be read
-            receivedData.attemptRead,
-            sentData.attemptWrite, // But only sent Data can be written
+            sentData.attemptWrite, // Sent Data can be written/modified
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
@@ -511,10 +509,11 @@ category ComputeResources {
         ->  read
 
       | read {C}
-        user info: "The attacker can read some or all of this service's code and data."
-        developer info: "We don't model the services data, as we do not expect that information will be available to the parser."
+        user info: "The attacker can read some or all of this service's code and data (both local and sent/received)."
         ->  containedData.attemptRead,
             appExecutedApps.attemptRead
+            sentData.attemptRead, // Both sent and received Data can also be read
+            receivedData.attemptRead,
 
       | attemptModify @hidden
         developer info: "Intermediate attack step to allow for defenses."
@@ -539,7 +538,8 @@ category ComputeResources {
       | deny {A}
         user info: "The attacker can deny some or all functionality and data pertaining to this application/service as well as executed applications."
         ->  containedData.attemptDeny,
-            appExecutedApps.attemptDeny
+            appExecutedApps.attemptDeny,
+            sentData.attemptDeny // Sent Data can also be denied
 
       & denyFromNetworkingAsset @hidden
         developer info: "This is an intermediate attack step to only allow deny on an application when all the connection rules and networks associated with it are denied, because an app can be serving on many different ports."

--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -302,12 +302,11 @@ category ComputeResources {
       | specificAccess
         user info: "The adversary is able to gain low-privilege access on the Application which allows them to access the networks and connections associated with it and locally connect to hosted Applications. Additionally, if they have the required privileges the attacker may also access data hosted, sent, or received by the Application."
         ->  appExecutedApps.localConnect, // An attacker with low-privilege access on the executing instance is assumed to be able to locally interact with the executed applications.
+            specificAccessRead,
+            specificAccessModify,
+            specificAccessDeny,
             bypassContainerization,
             attemptUseVulnerability, // Attempt to exploit all the vulnerabilities associated with the Application
-            containedData.authorizedAccessFromApplication, // This also enables the use of compromised permissions but only after those privileges are attained
-            sentData.authorizedReadFromApplication, // Both Data sent and received can be read given the necessary permissions
-            receivedData.authorizedReadFromApplication,
-            sentData.authorizedWriteFromApplication, // But only sent Data can be written given the necessary permissions
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections // and access the network(s) and connections on/to which the app is connected
 
@@ -343,10 +342,7 @@ category ComputeResources {
         ->  attemptRead,
             attemptModify,
             attemptDeny,
-            appExecutedApps.attemptModify, // Gain access on all applications executed by this (host) application
             executionPrivIAMs.attemptAssume,  // Assume also the execution privilege identities of this application to the access to the entire execution context
-            containedData.attemptAccess,  // and access on all the contained data
-            sentData.attemptWrite, // Sent Data can be written/modified
             attemptApplicationRespondConnectThroughData,
             accessNetworkAndConnections,  // and access the network(s) and connections on/to which the app is connected
             hostApp.localConnect,    // and localConnect on the host application
@@ -509,11 +505,17 @@ category ComputeResources {
         ->  read
 
       | read {C}
-        user info: "The attacker can read some or all of this service's code and data (both local and sent/received)."
+        user info: "The attacker can read some or all of this service's (and executed by this) source code and/or data (both local and sent/received)."
         ->  containedData.attemptRead,
-            appExecutedApps.attemptRead
-            sentData.attemptRead, // Both sent and received Data can also be read
-            receivedData.attemptRead,
+            appExecutedApps.attemptRead, // Read all applications executed by this (host) application
+            sentData.attemptRead, // Both sent and received Data can be read
+            receivedData.attemptRead
+
+      | specificAccessRead {C}
+        user info: "The attacker can read the service's source code and/or sent and received Data, given the necessary permissions"
+        ->  containedData.authorizedReadFromApplication,
+            sentData.authorizedReadFromApplication, // Both Data sent and received can be read given the necessary permissions
+            receivedData.authorizedReadFromApplication
 
       | attemptModify @hidden
         developer info: "Intermediate attack step to allow for defenses."
@@ -524,8 +526,16 @@ category ComputeResources {
         ->  modify
 
       | modify {I}
-        user info: "The attacker can modify some or all of this service's data and/or source code."
-        ->  fullAccess
+        user info: "The attacker can modify some or all of this service's (and executed by this) source code and/or data."
+        ->  fullAccess,
+            containedData.attemptWrite,
+            appExecutedApps.attemptModify, // Gain access on all applications executed by this (host) application
+            sentData.attemptWrite // Sent Data can be written/modified
+
+      | specificAccessModify {I}
+        user info: "The attacker can modify the service's source code and/or sent  Data, given the necessary permissions"
+        ->  containedData.authorizedWriteFromApplication,
+            sentData.authorizedWriteFromApplication // Sent Data can be written given the necessary permissions
 
       | attemptDeny @hidden
         developer info: "Intermediate attack step to allow for defenses."
@@ -540,6 +550,11 @@ category ComputeResources {
         ->  containedData.attemptDeny,
             appExecutedApps.attemptDeny,
             sentData.attemptDeny // Sent Data can also be denied
+
+      | specificAccessDeny {A}
+        user info: "The attacker can deny some or all functionality and data pertaining to this application/service as well as executed applications, given the necessary permissions"
+        ->  containedData.authorizedDeleteFromApplication,
+            sentData.authorizedDeleteFromApplication // Sent Data can be denied given the necessary permissions
 
       & denyFromNetworkingAsset @hidden
         developer info: "This is an intermediate attack step to only allow deny on an application when all the connection rules and networks associated with it are denied, because an app can be serving on many different ports."

--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -48,7 +48,8 @@ category ComputeResources {
       | fullAccess {C,I,A}
         user info: "Full access on a piece of hardware grants full access on the applications running on it and access to the hosted data."
         ->  sysExecutedApps.fullAccess,
-            hostedData.attemptAccess,
+            hostedData.attemptRead,
+            hostedData.attemptWrite,
             attemptSpreadWormThroughRemovableMedia
 
       | attemptSupplyChainAttack @entrypoint

--- a/src/main/mal/DataResources.mal
+++ b/src/main/mal/DataResources.mal
@@ -74,24 +74,13 @@ category DataResources {
       # notPresent [Disabled]
         user info: "This defense is used to reason about the attack vectors introduced by this asset. It should be used to model the possibility of data not existing on the associated container (i.e. Hardware, Application, Network, etc.)."
         developer info: "Enabling this defense should make the asset behave as if it did not exist, as such all of its impactful attack steps should be disabled by it."
-        ->  access,
-            applicationRespondConnect,
+        ->  applicationRespondConnect,
             successfulRead,
             successfulWrite,
             successfulDeny,
             successfulDelete,
             reverseReach,
             extract
-
-      | attemptAccess @hidden
-        developer info: "Intermediate attack step to allow for defenses."
-        ->  access
-
-      & access @hidden
-        developer info: "Access the data."
-        ->  attemptRead,
-            attemptWrite,
-            attemptDelete
 
       | authorizedAccessFromApplication @hidden
         developer info: "Try to gain access to the data through permissions."
@@ -134,8 +123,7 @@ category DataResources {
 
       | accessDecryptedData @hidden
         developer info: "Intermediate attack step to only allow effects of 'accessUnencryptedData' on data after compromising the encryption credentials or encryption is disabled."
-        ->  access,
-            applicationRespondConnect,
+        ->  applicationRespondConnect,
             successfulRead,
             successfulWrite,
             successfulDelete

--- a/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataPrivilegesTest.java
@@ -274,7 +274,8 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new DataToDataModel(false);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.top.access);
+        model.addAttacker(attacker, model.top.attemptRead);
+        model.addAttacker(attacker, model.top.attemptWrite);
         attacker.attack();
 
         // No access control at all:
@@ -295,7 +296,8 @@ public class DataPrivilegesTest extends CoreLangTest {
         var model = new DataToDataModel(true);
 
         var attacker = new Attacker();
-        model.addAttacker(attacker, model.top.access);
+        model.addAttacker(attacker, model.top.attemptRead);
+        model.addAttacker(attacker, model.top.attemptWrite);
         attacker.attack();
 
         model.mid.read.assertCompromisedInstantaneously();

--- a/src/test/java/org/mal_lang/corelang/test/DataTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/DataTest.java
@@ -29,10 +29,10 @@ public class DataTest extends CoreLangTest {
         var model = new DataTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.data1.attemptAccess);
+        model.addAttacker(attacker,model.data1.attemptRead);
+        model.addAttacker(attacker,model.data1.attemptWrite);
         attacker.attack();
 
-        model.data1.access.assertCompromisedInstantaneously();
         model.data1.read.assertCompromisedInstantaneously();
         model.data1.write.assertCompromisedInstantaneously();
         model.data1.delete.assertCompromisedInstantaneously();
@@ -58,7 +58,6 @@ public class DataTest extends CoreLangTest {
         var attacker = new Attacker();
         attacker.attack();
 
-        model.data1.access.assertUncompromised();
         model.data1.read.assertUncompromised();
         model.data1.write.assertUncompromised();
         model.data1.delete.assertUncompromised();
@@ -82,11 +81,11 @@ public class DataTest extends CoreLangTest {
         var model = new DataTestModel();
 
         var attacker = new Attacker();
-        model.addAttacker(attacker,model.data1.attemptAccess);
+        model.addAttacker(attacker,model.data1.attemptRead);
+        model.addAttacker(attacker,model.data1.attemptWrite);
         model.addAttacker(attacker,model.datacreds.use);
         attacker.attack();
 
-        model.data1.access.assertCompromisedInstantaneously();
         model.data1.read.assertCompromisedInstantaneously();
         model.data1.write.assertCompromisedInstantaneously();
         model.data1.delete.assertCompromisedInstantaneously();

--- a/src/test/java/org/mal_lang/corelang/test/HardwareTest.java
+++ b/src/test/java/org/mal_lang/corelang/test/HardwareTest.java
@@ -82,7 +82,8 @@ public class HardwareTest extends CoreLangTest {
         model.hardware.fullAccess.assertCompromisedInstantaneously();
         model.application.physicalAccessAchieved.assertCompromisedInstantaneously();
         model.application.fullAccess.assertCompromisedInstantaneously();
-        model.data.attemptAccess.assertCompromisedInstantaneously();
+        model.data.attemptRead.assertCompromisedInstantaneously();
+        model.data.attemptWrite.assertCompromisedInstantaneously();
     }
 
 }

--- a/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
+++ b/src/test/java/org/mal_lang/corelang/test/IAMIntegrationTests.java
@@ -53,7 +53,7 @@ public class IAMIntegrationTests extends CoreLangTest {
             // vuln.abuse.assertCompromisedInstantaneously();
             oracle.fullAccess.assertCompromisedWithEffort();
             rhel_oracle.assume.assertCompromisedWithEffort();
-            db.access.assertCompromisedWithEffort();
+            db.read.assertCompromisedWithEffort();
             table1.read.assertCompromisedWithEffort();
             table2.read.assertCompromisedWithEffort();
             rhel.fullAccess.assertCompromisedWithEffort();
@@ -106,12 +106,10 @@ public class IAMIntegrationTests extends CoreLangTest {
             data.authorizedReadFromIAM.assertCompromisedInstantaneously();
             data.authorizedWriteFromIAM.assertUncompromised();
             data.authorizedDeleteFromIAM.assertUncompromised();
-            data.attemptAccess.assertUncompromised();
             data.authorizedAccessFromApplication.assertUncompromised();
             data.authorizedReadFromApplication.assertUncompromised();
             data.authorizedWriteFromApplication.assertUncompromised();
             data.authorizedDeleteFromApplication.assertUncompromised();
-            data.access.assertUncompromised();
             data.read.assertUncompromised();
             data.write.assertUncompromised();
             data.delete.assertUncompromised();


### PR DESCRIPTION
This PR contains the fixes and improvements on how the `Data` instances can be manipulated after `specificAccess` or `fullAccess` is reached on an Application.