### PR TITLE
Fix Specific Access Application Network Connection Through Response

### DIFF
--- a/src/main/mal/ComputeResources.mal
+++ b/src/main/mal/ComputeResources.mal
@@ -203,6 +203,7 @@ category ComputeResources {
             modifyFromSoftProdVulnerability,
             denyFromSoftProdVulnerability,
             successfulApplicationRespondConnectThroughData,
+            successfulAuthorizedApplicationRespondConnectThroughData,
             successfulRead,
             successfulModify,
             successfulDeny
@@ -308,7 +309,7 @@ category ComputeResources {
             specificAccessDelete,
             bypassContainerization,
             attemptUseVulnerability, // Attempt to exploit all the vulnerabilities associated with the Application
-            attemptApplicationRespondConnectThroughData,
+            attemptAuthorizedApplicationRespondConnectThroughData,
             accessNetworkAndConnections // and access the network(s) and connections on/to which the app is connected
 
       | bypassContainerization [HardAndUncertain]
@@ -494,8 +495,20 @@ category ComputeResources {
         ->  applicationRespondConnectThroughData
 
       | applicationRespondConnectThroughData @hidden
-        developer info: "After access on the application the contained data or data in transit can be used to try a connect through Respond to the client side application."
+        developer info: "After full access on the application received data can be used to try a connect through respond to the client side application."
         ->  receivedData.attemptApplicationRespondConnect
+
+      | attemptAuthorizedApplicationRespondConnectThroughData @hidden
+        developer info: "Intermediate attack step to allow for defenses."
+        ->  successfulAuthorizedApplicationRespondConnectThroughData
+
+      & successfulAuthorizedApplicationRespondConnectThroughData @hidden
+        developer info: "Intermediate attack step to model defenses."
+        ->  authorizedApplicationRespondConnectThroughData
+
+      | authorizedApplicationRespondConnectThroughData @hidden
+        developer info: "After specific access on the application received data can be used to try a connect through respond to the client side application. To succeed the attacker must also attain write privileges on the received data."
+        ->  receivedData.authorizedApplicationRespondConnectFromApplication
 
       | attemptRead @hidden
         developer info: "Intermediate attack step to allow for defenses."

--- a/src/main/mal/DataResources.mal
+++ b/src/main/mal/DataResources.mal
@@ -133,9 +133,21 @@ category DataResources {
         ->  applicationRespondConnect
 
       & applicationRespondConnect @hidden
-        developer info: "If data are adversaryInTheMiddled or the server side application is compromised, then respond connect to the client side application can be done."
+        developer info: "In order to perform a respond connect attack the adversary must be able to write the received data."
         ->  senderApp.attemptNetworkConnectFromResponse,
             containedData.applicationRespondConnect
+
+      | authorizedApplicationRespondConnectFromApplication @hidden
+        developer info: "The adversary can attempt a respond connect attack from an Application, but they still require write permissions in order to perform it."
+        ->  authorizedApplicationRespondConnect
+
+      | authorizedApplicationRespondConnectFromIAM @hidden
+        developer info: "The attacker has obtained the access control permissions required to modify the incoming requests."
+        ->  authorizedApplicationRespondConnect
+
+      & authorizedApplicationRespondConnect @hidden
+        developer info: "In order to perform a respond connect attack the adversary must be able to write the received data. If they only have specific access on the Application we need to see if they also have the required permissions."
+        ->  attemptApplicationRespondConnect
 
       | attemptRead @hidden
         developer info: "Intermediate attack step to allow for defenses."

--- a/src/main/mal/IAM.mal
+++ b/src/main/mal/IAM.mal
@@ -40,6 +40,7 @@ category IAM {
             lowPrivApps.specificAccessAuthenticate,
             readPrivData.authorizedReadFromIAM,
             writePrivData.authorizedWriteFromIAM,
+            writePrivData.authorizedApplicationRespondConnectFromIAM,
             deletePrivData.authorizedDeleteFromIAM,
             managedIAMs.attemptAssume,
             subprivileges.attemptAssume


### PR DESCRIPTION
When attempting to write `Data` from an `Application` where the attacker has gained low-level privileges, `specificAccess`, we check to see if they have attained the required permissions. This should also be the case for a respond connect attack as it is the attacker manipulating the received `Data` to induce the creation of responses that give it control. This pull request introduces the `authorizedApplicationRespondConnectThroughData` attack step to implement that.