### PR TITLE
Introduce Inherent User Interaction for SoftwareVulnerabilities

### DIFF
--- a/src/main/mal/Vulnerability.mal
+++ b/src/main/mal/Vulnerability.mal
@@ -113,6 +113,12 @@ category Vulnerability {
       modeler info: "https://www.first.org/cvss/v3.1/specification-document#2-1-2-Attack-Complexity-AC"
       ->  exploitTrivially
 
+    | inherentUserInteraction [HardAndUncertain]
+      user info: "The user may fulfil the user interaction requirement through their regular activities, without requiring the attacker to induce them to do so."
+      modeler info: "Different software vulnerabilities that require user interaction to exploit can vary substantially in how likely those interactions are. They can range from simply using a shortcut or starting a service to enabling very specific features that the user would never perform without attacker influence. The probability assigned to this attack step should be tuned to fit the description of the vulnerability."
+      ->  userInteractionAchieved,
+          softwareProduct.softApplications.softwareProductVulnerabilityUserInteractionAchieved
+
     /* The following 10 attack steps are used to satisfy the requirements
      * that the defenses above specify. They are used if the defense is not
      * enabled or if the attacker is able to fulfil the requirement through
@@ -166,6 +172,10 @@ category Vulnerability {
       user info: "Denial-of-Service attack is an attack in which an application is rendered unavailable to its intended users by temporarily or indefinitely disrupting it."
       ->  application.deny,
           softwareProduct.denyApplications
+
+    | attemptAbuse @hidden
+      developer info: "Trigger inherent user interaction for software vulnerabilities, it is only relevant for vulnerabilities that do require user interaction."
+      +>  inherentUserInteraction
 
     | attemptExploit @hidden @Override
       developer info: "Intermediate attack step to allow for defenses."


### PR DESCRIPTION
One of the possible requirements of `SoftwareVulnerabilities` is `UserInteraction`. However, the CVSS score is binary, so it does not define the likelihood of the user triggering the interaction on their own. This feels too coarse as vulnerabilities can range quite substantially in the user interaction required. Some could require behaviour that is reasonable to expect regularly, such as clicking on a shortcut or accessing network storage, while other may require behaviour that is unlikely to happen unless the user is tricked into the specific interaction.

We have been using the `unsafeUserActivity` attack step to fulfil this requirement so far. However, this entirely disregards the possibility that the user would trigger the required interaction without adversary inducement. This pull request introduces an attack step, `inherentUserInteraction`, that automatically fulfils the requirement, representing the user triggering it as part of their regular operations. However, the probability associated with this attack step is entirely vulnerability dependent, so the modeller should assign an appropriate distribution given the description of the vulnerability.